### PR TITLE
Auto-updating Spryker modules on 2023-11-29 15:37

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -157,6 +157,7 @@
         "spryker/glue-backend-api-application-glue-json-api-convention-connector": "^1.0.0",
         "spryker/glue-storefront-api-application-authorization-connector": "^1.0.0",
         "spryker/glue-storefront-api-application-glue-json-api-convention-connector": "^1.0.0",
+        "spryker/merchant-profile-gui": "1.1.0",
         "spryker/message-broker": "^1.4.0",
         "spryker/message-broker-aws": "^1.4.0",
         "spryker/money-gui": "^1.0.0",
@@ -201,6 +202,7 @@
         "spryker/product-label-discount-connector": "^3.1.0",
         "spryker/product-labels-rest-api": "^1.3.0",
         "spryker/product-measurement-units-rest-api": "^1.1.0",
+        "spryker/product-merchant-portal-gui": "3.3.0",
         "spryker/product-option-cart-connector": "^7.1.2",
         "spryker/product-options-rest-api": "^1.2.0",
         "spryker/product-prices-rest-api": "^1.6.0",
@@ -232,6 +234,7 @@
         "spryker/tax-product-connector": "^4.5.1",
         "spryker/up-selling-products-rest-api": "^1.2.2",
         "spryker/urls-rest-api": "^1.0.2",
+        "spryker/user-merchant-portal-gui": "2.3.0",
         "spryker/util-number": "^1.0.0",
         "spryker/uuid": "^1.0.1",
         "symfony/http-kernel": "^v5.4.20"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a7acca786f335487a582d73bd80133e",
+    "content-hash": "16565d4caa5a09bc10b5f5c6569b8fde",
     "packages": [
         {
             "name": "async-aws/core",
@@ -335,26 +335,25 @@
         },
         {
             "name": "brick/math",
-            "version": "0.10.2",
+            "version": "0.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "459f2781e1a08d52ee56b0b1444086e038561e3f"
+                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/459f2781e1a08d52ee56b0b1444086e038561e3f",
-                "reference": "459f2781e1a08d52ee56b0b1444086e038561e3f",
+                "url": "https://api.github.com/repos/brick/math/zipball/0ad82ce168c82ba30d1c01ec86116ab52f589478",
+                "reference": "0ad82ce168c82ba30d1c01ec86116ab52f589478",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
-                "php": "^7.4 || ^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
                 "phpunit/phpunit": "^9.0",
-                "vimeo/psalm": "4.25.0"
+                "vimeo/psalm": "5.0.0"
             },
             "type": "library",
             "autoload": {
@@ -379,7 +378,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.10.2"
+                "source": "https://github.com/brick/math/tree/0.11.0"
             },
             "funding": [
                 {
@@ -387,7 +386,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-10T22:54:19+00:00"
+            "time": "2023-01-15T23:15:59+00:00"
         },
         {
             "name": "cebe/php-openapi",
@@ -526,25 +525,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "v1.0.0",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
+                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
+                "reference": "4f2d4f2836e7ec4e7a8625e75c6aa916004db931",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9",
-                "phpunit/phpunit": "^7.5|^8.5|^9.5",
-                "psr/log": "^1|^2|^3"
+                "phpstan/phpstan": "1.4.10 || 1.10.15",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "0.18.4",
+                "psr/log": "^1 || ^2 || ^3",
+                "vimeo/psalm": "4.30.0 || 5.12.0"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -563,34 +566,34 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.2"
             },
-            "time": "2022-05-02T15:47:09+00:00"
+            "time": "2023-09-27T20:04:15+00:00"
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.0.6",
+            "version": "2.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "d9d313a36c872fd6ee06d9a6cbcf713eaa40f024"
+                "reference": "f9301a5b2fb1216b2b08f02ba04dc45423db6bff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/d9d313a36c872fd6ee06d9a6cbcf713eaa40f024",
-                "reference": "d9d313a36c872fd6ee06d9a6cbcf713eaa40f024",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/f9301a5b2fb1216b2b08f02ba04dc45423db6bff",
+                "reference": "f9301a5b2fb1216b2b08f02ba04dc45423db6bff",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^10",
+                "doctrine/coding-standard": "^11.0",
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-phpunit": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.3",
                 "phpunit/phpunit": "^8.5 || ^9.5",
-                "vimeo/psalm": "^4.25"
+                "vimeo/psalm": "^4.25 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -640,7 +643,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.6"
+                "source": "https://github.com/doctrine/inflector/tree/2.0.8"
             },
             "funding": [
                 {
@@ -656,7 +659,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-20T09:10:12+00:00"
+            "time": "2023-06-16T13:40:37+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -738,16 +741,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "3.2.5",
+            "version": "3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "b531a2311709443320c786feb4519cfaf94af796"
+                "reference": "e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/b531a2311709443320c786feb4519cfaf94af796",
-                "reference": "b531a2311709443320c786feb4519cfaf94af796",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7",
+                "reference": "e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7",
                 "shasum": ""
             },
             "require": {
@@ -793,7 +796,7 @@
             ],
             "support": {
                 "issues": "https://github.com/egulias/EmailValidator/issues",
-                "source": "https://github.com/egulias/EmailValidator/tree/3.2.5"
+                "source": "https://github.com/egulias/EmailValidator/tree/3.2.6"
             },
             "funding": [
                 {
@@ -801,20 +804,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T17:26:14+00:00"
+            "time": "2023-06-01T07:04:22+00:00"
         },
         {
             "name": "elasticsearch/elasticsearch",
-            "version": "v7.17.1",
+            "version": "v7.17.2",
             "source": {
                 "type": "git",
                 "url": "git@github.com:elastic/elasticsearch-php.git",
-                "reference": "f1b8918f411b837ce5f6325e829a73518fd50367"
+                "reference": "2d302233f2bb0926812d82823bb820d405e130fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/f1b8918f411b837ce5f6325e829a73518fd50367",
-                "reference": "f1b8918f411b837ce5f6325e829a73518fd50367",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/2d302233f2bb0926812d82823bb820d405e130fc",
+                "reference": "2d302233f2bb0926812d82823bb820d405e130fc",
                 "shasum": ""
             },
             "require": {
@@ -827,7 +830,7 @@
                 "ext-yaml": "*",
                 "ext-zip": "*",
                 "mockery/mockery": "^1.2",
-                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan": "^1.10",
                 "phpunit/phpunit": "^9.3",
                 "squizlabs/php_codesniffer": "^3.4",
                 "symfony/finder": "~4.0"
@@ -864,7 +867,7 @@
                 "elasticsearch",
                 "search"
             ],
-            "time": "2022-09-30T12:28:55+00:00"
+            "time": "2023-04-21T15:31:12+00:00"
         },
         {
             "name": "everon/collection",
@@ -1164,22 +1167,22 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.5.0",
+            "version": "7.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba"
+                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b50a2a1251152e43f6a37f0fa053e730a67d25ba",
-                "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1110f66a6530a40fe7aea0378fe608ee2b2248f9",
+                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5",
-                "guzzlehttp/psr7": "^1.9 || ^2.4",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.1",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.5.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -1190,7 +1193,8 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.1",
                 "ext-curl": "*",
-                "php-http/client-integration-tests": "^3.0",
+                "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
+                "php-http/message-factory": "^1.1",
                 "phpunit/phpunit": "^8.5.29 || ^9.5.23",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
@@ -1204,9 +1208,6 @@
                 "bamarni-bin": {
                     "bin-links": true,
                     "forward-command": false
-                },
-                "branch-alias": {
-                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -1272,7 +1273,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.5.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.8.0"
             },
             "funding": [
                 {
@@ -1288,20 +1289,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T15:39:27+00:00"
+            "time": "2023-08-27T10:20:53+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598"
+                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/b94b2807d85443f9719887892882d0329d1e2598",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/67ab6e18aaa14d753cc148911d273f6e6cb6721e",
+                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e",
                 "shasum": ""
             },
             "require": {
@@ -1311,11 +1312,6 @@
                 "symfony/phpunit-bridge": "^4.4 || ^5.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "src/functions_include.php"
@@ -1356,7 +1352,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.2"
+                "source": "https://github.com/guzzle/promises/tree/1.5.3"
             },
             "funding": [
                 {
@@ -1372,26 +1368,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:55:35+00:00"
+            "time": "2023-05-21T12:31:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.4.5",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "0454e12ef0cd597ccd2adb036f7bda4e7fface66"
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/0454e12ef0cd597ccd2adb036f7bda4e7fface66",
-                "reference": "0454e12ef0cd597ccd2adb036f7bda4e7fface66",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0"
             },
             "provide": {
@@ -1472,7 +1468,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.4.5"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.1"
             },
             "funding": [
                 {
@@ -1488,7 +1484,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-17T16:00:45+00:00"
+            "time": "2023-08-27T10:13:57+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -1622,22 +1618,22 @@
         },
         {
             "name": "laminas/laminas-config",
-            "version": "3.8.0",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-config.git",
-                "reference": "46baad58d0b12cf98539e04334eff40a1fdfb9a0"
+                "reference": "e53717277f6c22b1c697a46473b9a5ec9a438efa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/46baad58d0b12cf98539e04334eff40a1fdfb9a0",
-                "reference": "46baad58d0b12cf98539e04334eff40a1fdfb9a0",
+                "url": "https://api.github.com/repos/laminas/laminas-config/zipball/e53717277f6c22b1c697a46473b9a5ec9a438efa",
+                "reference": "e53717277f6c22b1c697a46473b9a5ec9a438efa",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "laminas/laminas-stdlib": "^3.6",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
@@ -1686,7 +1682,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-16T14:21:22+00:00"
+            "time": "2023-09-19T12:02:54+00:00"
         },
         {
             "name": "laminas/laminas-filter",
@@ -2895,16 +2891,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.9.1",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1"
+                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
-                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
+                "reference": "437cb3628f4cf6042cc10ae97fc2b8472e48ca1f",
                 "shasum": ""
             },
             "require": {
@@ -2981,7 +2977,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.9.1"
+                "source": "https://github.com/Seldaek/monolog/tree/2.9.2"
             },
             "funding": [
                 {
@@ -2993,7 +2989,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-06T13:44:46+00:00"
+            "time": "2023-10-27T15:25:26+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -3817,21 +3813,21 @@
         },
         {
             "name": "psr/http-client",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-client.git",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -3851,7 +3847,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP clients",
@@ -3863,27 +3859,27 @@
                 "psr-18"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-client/tree/master"
+                "source": "https://github.com/php-fig/http-client"
             },
-            "time": "2020-06-29T06:28:15+00:00"
+            "time": "2023-09-23T14:17:50+00:00"
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.0.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -3903,7 +3899,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for PSR-7 HTTP message factories",
@@ -3918,31 +3914,31 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/master"
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
             },
-            "time": "2019-04-30T12:38:16+00:00"
+            "time": "2023-04-10T20:10:41+00:00"
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -3971,9 +3967,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         },
         {
             "name": "psr/log",
@@ -4161,20 +4157,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.7.3",
+            "version": "4.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "433b2014e3979047db08a17a205f410ba3869cf2"
+                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/433b2014e3979047db08a17a205f410ba3869cf2",
-                "reference": "433b2014e3979047db08a17a205f410ba3869cf2",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
+                "reference": "5f0df49ae5ad6efb7afa69e6bfab4e5b1e080d8e",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10",
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11",
                 "ext-json": "*",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
@@ -4237,7 +4233,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.7.3"
+                "source": "https://github.com/ramsey/uuid/tree/4.7.5"
             },
             "funding": [
                 {
@@ -4249,27 +4245,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-12T18:13:24+00:00"
+            "time": "2023-11-08T05:53:05+00:00"
         },
         {
             "name": "react/promise",
-            "version": "v2.9.0",
+            "version": "v2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910"
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/234f8fd1023c9158e2314fa9d7d0e6a83db42910",
-                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/1a8460931ea36dc5c76838fec5734d55c88c6831",
+                "reference": "1a8460931ea36dc5c76838fec5734d55c88c6831",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.36"
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
             },
             "type": "library",
             "autoload": {
@@ -4313,19 +4309,15 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.9.0"
+                "source": "https://github.com/reactphp/promise/tree/v2.11.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-02-11T10:27:51+00:00"
+            "time": "2023-11-16T16:16:50+00:00"
         },
         {
             "name": "riskio/oauth2-auth0",
@@ -4382,16 +4374,16 @@
         },
         {
             "name": "ruflin/elastica",
-            "version": "7.3.0",
+            "version": "7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ruflin/Elastica.git",
-                "reference": "75fca5bf2b6792d35dae6c5efeda2322bce914e4"
+                "reference": "7c61a630c3d456b00a5610960ae3a9bd29987469"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/75fca5bf2b6792d35dae6c5efeda2322bce914e4",
-                "reference": "75fca5bf2b6792d35dae6c5efeda2322bce914e4",
+                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/7c61a630c3d456b00a5610960ae3a9bd29987469",
+                "reference": "7c61a630c3d456b00a5610960ae3a9bd29987469",
                 "shasum": ""
             },
             "require": {
@@ -4445,9 +4437,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ruflin/Elastica/issues",
-                "source": "https://github.com/ruflin/Elastica/tree/7.3.0"
+                "source": "https://github.com/ruflin/Elastica/tree/7.3.1"
             },
-            "time": "2022-11-30T14:21:43+00:00"
+            "time": "2023-04-21T09:04:46+00:00"
         },
         {
             "name": "seld/signal-handler",
@@ -14988,16 +14980,16 @@
         },
         {
             "name": "spryker/acl",
-            "version": "3.17.0",
+            "version": "3.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/acl.git",
-                "reference": "08d01d97f64db664548da1736129152d3b1c92ff"
+                "reference": "df25104e32fe82691e34e405b0d2a034c32a6800"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/acl/zipball/08d01d97f64db664548da1736129152d3b1c92ff",
-                "reference": "08d01d97f64db664548da1736129152d3b1c92ff",
+                "url": "https://api.github.com/repos/spryker/acl/zipball/df25104e32fe82691e34e405b0d2a034c32a6800",
+                "reference": "df25104e32fe82691e34e405b0d2a034c32a6800",
                 "shasum": ""
             },
             "require": {
@@ -15026,6 +15018,7 @@
                 "spryker/propel": "*",
                 "spryker/router": "*",
                 "spryker/silex": "*",
+                "spryker/store": "*",
                 "spryker/testify": "*",
                 "spryker/twig": "*",
                 "spryker/validator": "*",
@@ -15056,9 +15049,9 @@
             ],
             "description": "Acl module",
             "support": {
-                "source": "https://github.com/spryker/acl/tree/3.17.0"
+                "source": "https://github.com/spryker/acl/tree/3.17.1"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/acl-entity-extension",
@@ -15473,16 +15466,16 @@
         },
         {
             "name": "spryker/application",
-            "version": "3.31.0",
+            "version": "3.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/application.git",
-                "reference": "6cbe91a3734eb2a3924fe59f7c289d9ff8ed50f7"
+                "reference": "103ae41d2fe45641d6ec295990ff5c789cb1bee6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/application/zipball/6cbe91a3734eb2a3924fe59f7c289d9ff8ed50f7",
-                "reference": "6cbe91a3734eb2a3924fe59f7c289d9ff8ed50f7",
+                "url": "https://api.github.com/repos/spryker/application/zipball/103ae41d2fe45641d6ec295990ff5c789cb1bee6",
+                "reference": "103ae41d2fe45641d6ec295990ff5c789cb1bee6",
                 "shasum": ""
             },
             "require": {
@@ -15496,7 +15489,7 @@
                 "spryker/log": "^3.1.0",
                 "spryker/monolog": "^2.0.0",
                 "spryker/propel-orm": "^1.0.0",
-                "spryker/symfony": "^3.5.0",
+                "spryker/symfony": "^3.9.0",
                 "spryker/twig": "^3.13.0",
                 "spryker/twig-extension": "^1.0.0",
                 "spryker/util-encoding": "^2.0.0",
@@ -15534,9 +15527,9 @@
             ],
             "description": "Application module",
             "support": {
-                "source": "https://github.com/spryker/application/tree/3.31.0"
+                "source": "https://github.com/spryker/application/tree/3.34.0"
             },
-            "time": "2023-01-24T16:01:46+00:00"
+            "time": "2023-10-20T11:09:01+00:00"
         },
         {
             "name": "spryker/application-extension",
@@ -16076,16 +16069,16 @@
         },
         {
             "name": "spryker/availability",
-            "version": "9.17.0",
+            "version": "9.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/availability.git",
-                "reference": "c6b7bb451fd9fc7ff339fd6321dc2276a3a90d89"
+                "reference": "ca1b297e7181a45183d614236d5b6f7b50f7c41a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/availability/zipball/c6b7bb451fd9fc7ff339fd6321dc2276a3a90d89",
-                "reference": "c6b7bb451fd9fc7ff339fd6321dc2276a3a90d89",
+                "url": "https://api.github.com/repos/spryker/availability/zipball/ca1b297e7181a45183d614236d5b6f7b50f7c41a",
+                "reference": "ca1b297e7181a45183d614236d5b6f7b50f7c41a",
                 "shasum": ""
             },
             "require": {
@@ -16093,10 +16086,11 @@
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/availability-extension": "^1.2.0",
                 "spryker/decimal-object": "^1.0.0",
+                "spryker/dynamic-entity-extension": "^1.0.0",
                 "spryker/event": "^2.3.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/key-builder": "^1.0.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/oms": "^11.0.0",
                 "spryker/oms-extension": "^1.2.0",
                 "spryker/product": "^5.0.0 || ^6.0.0",
@@ -16106,16 +16100,18 @@
                 "spryker/stock": "^8.1.0",
                 "spryker/stock-extension": "^1.0.0",
                 "spryker/storage": "^3.0.0",
-                "spryker/store": "^1.5.0",
+                "spryker/store": "^1.19.0",
                 "spryker/touch": "^3.0.0 || ^4.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/wishlist-extension": "^1.2.0",
                 "spryker/zed-request": "^3.0.0"
             },
             "require-dev": {
                 "spryker/checkout": "*",
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/propel": "*",
+                "spryker/store-extension": "*",
                 "spryker/testify": "*"
             },
             "suggest": {
@@ -16139,9 +16135,9 @@
             ],
             "description": "Availability module",
             "support": {
-                "source": "https://github.com/spryker/availability/tree/9.17.0"
+                "source": "https://github.com/spryker/availability/tree/9.20.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-11-01T10:06:20+00:00"
         },
         {
             "name": "spryker/availability-cart-connector",
@@ -17089,20 +17085,20 @@
         },
         {
             "name": "spryker/calculation",
-            "version": "4.12.0",
+            "version": "4.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/calculation.git",
-                "reference": "c27fe745b95c5732799b54fa0c49fad7536aa81f"
+                "reference": "49f5fa8855b00ebd987add60f2f57a9ac536f222"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/calculation/zipball/c27fe745b95c5732799b54fa0c49fad7536aa81f",
-                "reference": "c27fe745b95c5732799b54fa0c49fad7536aa81f",
+                "url": "https://api.github.com/repos/spryker/calculation/zipball/49f5fa8855b00ebd987add60f2f57a9ac536f222",
+                "reference": "49f5fa8855b00ebd987add60f2f57a9ac536f222",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
                 "spryker/calculation-extension": "^1.1.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/util-text": "^1.1.0",
@@ -17135,9 +17131,9 @@
             ],
             "description": "Calculation module",
             "support": {
-                "source": "https://github.com/spryker/calculation/tree/4.12.0"
+                "source": "https://github.com/spryker/calculation/tree/4.12.1"
             },
-            "time": "2022-02-02T14:07:33+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/calculation-extension",
@@ -17297,24 +17293,23 @@
         },
         {
             "name": "spryker/cart-code-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cart-code-extension.git",
-                "reference": "486d311261bdb1a96e519da69bd9f7a6b4df7010"
+                "reference": "8fedde427ed5852c59f3594543aeeba368179ed8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/cart-code-extension/zipball/486d311261bdb1a96e519da69bd9f7a6b4df7010",
-                "reference": "486d311261bdb1a96e519da69bd9f7a6b4df7010",
+                "url": "https://api.github.com/repos/spryker/cart-code-extension/zipball/8fedde427ed5852c59f3594543aeeba368179ed8",
+                "reference": "8fedde427ed5852c59f3594543aeeba368179ed8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=8.0"
             },
             "require-dev": {
-                "spryker/code-sniffer": "*",
-                "spryker/testify": "*"
+                "spryker/code-sniffer": "*"
             },
             "type": "library",
             "extra": {
@@ -17333,9 +17328,9 @@
             ],
             "description": "CartCodeExtension module",
             "support": {
-                "source": "https://github.com/spryker/cart-code-extension/tree/master"
+                "source": "https://github.com/spryker/cart-code-extension/tree/1.2.0"
             },
-            "time": "2019-12-04T15:11:36+00:00"
+            "time": "2023-06-23T09:24:33+00:00"
         },
         {
             "name": "spryker/cart-codes-rest-api",
@@ -18166,16 +18161,16 @@
         },
         {
             "name": "spryker/category",
-            "version": "5.12.0",
+            "version": "5.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/category.git",
-                "reference": "c831afb53adbea5b26bd41c22afc9c168977c82f"
+                "reference": "09187a8265547b2ef1493c03353c8a29a317fea0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/category/zipball/c831afb53adbea5b26bd41c22afc9c168977c82f",
-                "reference": "c831afb53adbea5b26bd41c22afc9c168977c82f",
+                "url": "https://api.github.com/repos/spryker/category/zipball/09187a8265547b2ef1493c03353c8a29a317fea0",
+                "reference": "09187a8265547b2ef1493c03353c8a29a317fea0",
                 "shasum": ""
             },
             "require": {
@@ -18184,7 +18179,7 @@
                 "spryker/category-extension": "^1.2.0",
                 "spryker/event": "^2.3.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/propel": "^3.0.0",
                 "spryker/propel-orm": "^1.0.0",
                 "spryker/store": "^1.0.0",
@@ -18217,9 +18212,9 @@
             ],
             "description": "Category module",
             "support": {
-                "source": "https://github.com/spryker/category/tree/5.12.0"
+                "source": "https://github.com/spryker/category/tree/5.14.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-10-30T14:48:01+00:00"
         },
         {
             "name": "spryker/category-data-feed",
@@ -19002,16 +18997,16 @@
         },
         {
             "name": "spryker/checkout",
-            "version": "6.4.2",
+            "version": "6.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/checkout.git",
-                "reference": "1a877dcdc9ff95ff0801675bef3f02d48c73bcec"
+                "reference": "d41c58ffe3e445a21b81abc2422e5f0b72692939"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/checkout/zipball/1a877dcdc9ff95ff0801675bef3f02d48c73bcec",
-                "reference": "1a877dcdc9ff95ff0801675bef3f02d48c73bcec",
+                "url": "https://api.github.com/repos/spryker/checkout/zipball/d41c58ffe3e445a21b81abc2422e5f0b72692939",
+                "reference": "d41c58ffe3e445a21b81abc2422e5f0b72692939",
                 "shasum": ""
             },
             "require": {
@@ -19030,6 +19025,7 @@
             "require-dev": {
                 "spryker/availability": "*",
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/country": "*",
                 "spryker/customer": "*",
                 "spryker/product": "*",
@@ -19056,9 +19052,9 @@
             ],
             "description": "Checkout module",
             "support": {
-                "source": "https://github.com/spryker/checkout/tree/6.4.2"
+                "source": "https://github.com/spryker/checkout/tree/6.4.4"
             },
-            "time": "2023-02-13T09:14:12+00:00"
+            "time": "2023-05-05T18:20:59+00:00"
         },
         {
             "name": "spryker/checkout-extension",
@@ -19252,16 +19248,16 @@
         },
         {
             "name": "spryker/cms",
-            "version": "7.11.2",
+            "version": "7.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cms.git",
-                "reference": "50a984320d0976c4f919d8ef02f7a9a3b75dd6c6"
+                "reference": "901662d38638a67933f45efd111556bc3116c370"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/cms/zipball/50a984320d0976c4f919d8ef02f7a9a3b75dd6c6",
-                "reference": "50a984320d0976c4f919d8ef02f7a9a3b75dd6c6",
+                "url": "https://api.github.com/repos/spryker/cms/zipball/901662d38638a67933f45efd111556bc3116c370",
+                "reference": "901662d38638a67933f45efd111556bc3116c370",
                 "shasum": ""
             },
             "require": {
@@ -19269,7 +19265,7 @@
                 "spryker/category": "^3.0.0 || ^4.0.0 || ^5.0.0",
                 "spryker/cms-extension": "^1.1.0",
                 "spryker/glossary": "^3.1.0",
-                "spryker/gui": "^3.42.0",
+                "spryker/gui": "^3.48.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/locale": "^3.0.0",
                 "spryker/propel-orm": "^1.0.0",
@@ -19316,31 +19312,32 @@
             ],
             "description": "Cms module",
             "support": {
-                "source": "https://github.com/spryker/cms/tree/7.11.2"
+                "source": "https://github.com/spryker/cms/tree/7.12.0"
             },
-            "time": "2022-12-29T12:04:01+00:00"
+            "time": "2023-03-13T13:20:27+00:00"
         },
         {
             "name": "spryker/cms-block",
-            "version": "3.4.0",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cms-block.git",
-                "reference": "8894ada787e8801c74d16faa79d4b256bb38d0bb"
+                "reference": "2be6a3b9f2563a392ad14a7a48e32b99c341c978"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/cms-block/zipball/8894ada787e8801c74d16faa79d4b256bb38d0bb",
-                "reference": "8894ada787e8801c74d16faa79d4b256bb38d0bb",
+                "url": "https://api.github.com/repos/spryker/cms-block/zipball/2be6a3b9f2563a392ad14a7a48e32b99c341c978",
+                "reference": "2be6a3b9f2563a392ad14a7a48e32b99c341c978",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
+                "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/cms-block-extension": "^1.0.0",
                 "spryker/event": "^2.0.0",
                 "spryker/glossary": "^3.1.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/propel-orm": "^1.0.0",
                 "spryker/store": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
@@ -19377,9 +19374,9 @@
             ],
             "description": "CmsBlock module",
             "support": {
-                "source": "https://github.com/spryker/cms-block/tree/3.4.0"
+                "source": "https://github.com/spryker/cms-block/tree/3.6.0"
             },
-            "time": "2022-01-04T12:43:20+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/cms-block-category-connector",
@@ -19546,23 +19543,23 @@
         },
         {
             "name": "spryker/cms-block-gui",
-            "version": "2.9.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cms-block-gui.git",
-                "reference": "3a1deae431f0089142602db60fd0b6a0691d21d5"
+                "reference": "90391049ef610848c8a5a134479ff48572c06902"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/cms-block-gui/zipball/3a1deae431f0089142602db60fd0b6a0691d21d5",
-                "reference": "3a1deae431f0089142602db60fd0b6a0691d21d5",
+                "url": "https://api.github.com/repos/spryker/cms-block-gui/zipball/90391049ef610848c8a5a134479ff48572c06902",
+                "reference": "90391049ef610848c8a5a134479ff48572c06902",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
                 "spryker/cms-block": "^2.0.0 || ^3.0.0",
                 "spryker/cms-block-gui-extension": "^1.0.0",
-                "spryker/gui": "^3.45.0",
+                "spryker/gui": "^3.48.0",
                 "spryker/kernel": "^3.52.0",
                 "spryker/locale": "^3.0.0",
                 "spryker/propel-orm": "^1.0.0",
@@ -19603,9 +19600,9 @@
             ],
             "description": "CmsBlockGui module",
             "support": {
-                "source": "https://github.com/spryker/cms-block-gui/tree/2.9.0"
+                "source": "https://github.com/spryker/cms-block-gui/tree/2.10.0"
             },
-            "time": "2022-09-19T06:48:51+00:00"
+            "time": "2023-03-13T13:20:27+00:00"
         },
         {
             "name": "spryker/cms-block-gui-extension",
@@ -20279,25 +20276,25 @@
         },
         {
             "name": "spryker/cms-gui",
-            "version": "5.10.0",
+            "version": "5.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/cms-gui.git",
-                "reference": "4febe0821cfaeab2316efa54151a2583047245f2"
+                "reference": "2050c26c2fbfda84737b7d51c559c6c338abfb72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/cms-gui/zipball/4febe0821cfaeab2316efa54151a2583047245f2",
-                "reference": "4febe0821cfaeab2316efa54151a2583047245f2",
+                "url": "https://api.github.com/repos/spryker/cms-gui/zipball/2050c26c2fbfda84737b7d51c559c6c338abfb72",
+                "reference": "2050c26c2fbfda84737b7d51c559c6c338abfb72",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
                 "spryker/application": "^3.2.0",
                 "spryker/cms": "^7.0.0",
                 "spryker/cms-gui-extension": "^1.0.0",
                 "spryker/glossary": "^3.0.0",
-                "spryker/gui": "^3.45.0",
+                "spryker/gui": "^3.48.0",
                 "spryker/kernel": "^3.52.0",
                 "spryker/locale": "^3.0.0",
                 "spryker/symfony": "^3.0.0",
@@ -20337,9 +20334,9 @@
             ],
             "description": "CmsGui module",
             "support": {
-                "source": "https://github.com/spryker/cms-gui/tree/5.10.0"
+                "source": "https://github.com/spryker/cms-gui/tree/5.11.0"
             },
-            "time": "2022-09-19T06:48:51+00:00"
+            "time": "2023-03-13T13:20:27+00:00"
         },
         {
             "name": "spryker/cms-gui-extension",
@@ -21733,16 +21730,16 @@
         },
         {
             "name": "spryker/collector",
-            "version": "6.7.2",
+            "version": "6.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/collector.git",
-                "reference": "fe904a59e7e8d51ddfba7ea42fc8543a8c3ce2c6"
+                "reference": "e5e8e980cb28843f59d978b670248c67cbdf9d0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/collector/zipball/fe904a59e7e8d51ddfba7ea42fc8543a8c3ce2c6",
-                "reference": "fe904a59e7e8d51ddfba7ea42fc8543a8c3ce2c6",
+                "url": "https://api.github.com/repos/spryker/collector/zipball/e5e8e980cb28843f59d978b670248c67cbdf9d0a",
+                "reference": "e5e8e980cb28843f59d978b670248c67cbdf9d0a",
                 "shasum": ""
             },
             "require": {
@@ -21752,7 +21749,7 @@
                 "spryker/gui": "^3.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/key-builder": "^1.1.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/propel": "^3.0.0",
                 "spryker/propel-orm": "^1.0.0",
                 "spryker/redis": "^2.0.0",
@@ -21767,6 +21764,7 @@
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/testify": "*"
             },
             "type": "library",
@@ -21787,9 +21785,9 @@
             ],
             "description": "Collector module",
             "support": {
-                "source": "https://github.com/spryker/collector/tree/6.7.2"
+                "source": "https://github.com/spryker/collector/tree/6.8.0"
             },
-            "time": "2023-01-24T16:01:46+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/comment",
@@ -24100,20 +24098,20 @@
         },
         {
             "name": "spryker/config",
-            "version": "3.5.2",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/config.git",
-                "reference": "656bfdca5adcfc39feda7d848472ea3ca78e7caf"
+                "reference": "32b617980b9cecb49277e6ba0d985e75fc491a99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/config/zipball/656bfdca5adcfc39feda7d848472ea3ca78e7caf",
-                "reference": "656bfdca5adcfc39feda7d848472ea3ca78e7caf",
+                "url": "https://api.github.com/repos/spryker/config/zipball/32b617980b9cecb49277e6ba0d985e75fc491a99",
+                "reference": "32b617980b9cecb49277e6ba0d985e75fc491a99",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
+                "php": ">=8.0",
                 "spryker/kernel": "^3.48.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/web-profiler-extension": "^1.0.0"
@@ -24149,9 +24147,9 @@
             ],
             "description": "Config module",
             "support": {
-                "source": "https://github.com/spryker/config/tree/3.5.2"
+                "source": "https://github.com/spryker/config/tree/3.6.0"
             },
-            "time": "2020-09-25T05:35:53+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/configurable-bundle",
@@ -24786,16 +24784,16 @@
         },
         {
             "name": "spryker/console",
-            "version": "4.11.0",
+            "version": "4.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/console.git",
-                "reference": "8eedac3bb9b5d9e081074554fe927e5743c397dd"
+                "reference": "fc1274867489936df0a28f55ab61a803cf27daf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/console/zipball/8eedac3bb9b5d9e081074554fe927e5743c397dd",
-                "reference": "8eedac3bb9b5d9e081074554fe927e5743c397dd",
+                "url": "https://api.github.com/repos/spryker/console/zipball/fc1274867489936df0a28f55ab61a803cf27daf9",
+                "reference": "fc1274867489936df0a28f55ab61a803cf27daf9",
                 "shasum": ""
             },
             "require": {
@@ -24841,9 +24839,9 @@
             ],
             "description": "Console module",
             "support": {
-                "source": "https://github.com/spryker/console/tree/4.11.0"
+                "source": "https://github.com/spryker/console/tree/4.12.0"
             },
-            "time": "2023-01-24T16:01:46+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/container",
@@ -26110,16 +26108,16 @@
         },
         {
             "name": "spryker/customer",
-            "version": "7.50.0",
+            "version": "7.51.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/customer.git",
-                "reference": "41b458793e76d193284c87e5524138bee0c29faf"
+                "reference": "a2ade8879cae2b33b2094a4771d317086a6178b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/customer/zipball/41b458793e76d193284c87e5524138bee0c29faf",
-                "reference": "41b458793e76d193284c87e5524138bee0c29faf",
+                "url": "https://api.github.com/repos/spryker/customer/zipball/a2ade8879cae2b33b2094a4771d317086a6178b9",
+                "reference": "a2ade8879cae2b33b2094a4771d317086a6178b9",
                 "shasum": ""
             },
             "require": {
@@ -26127,11 +26125,11 @@
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/authorization-extension": "^1.0.0",
                 "spryker/checkout-extension": "^1.2.0",
-                "spryker/country": "^3.0.0",
+                "spryker/country": "^3.1.0 || ^4.0.0",
                 "spryker/customer-extension": "^1.4.0",
                 "spryker/gui": "^3.39.0",
-                "spryker/kernel": "^3.52.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/kernel": "^3.72.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/mail": "^4.6.0",
                 "spryker/mail-extension": "^1.0.0",
                 "spryker/propel": "^3.0.0",
@@ -26139,7 +26137,7 @@
                 "spryker/router": "^1.12.0",
                 "spryker/sequence-number": "^3.0.0",
                 "spryker/session": "^3.0.0 || ^4.0.0",
-                "spryker/store": "^1.4.0",
+                "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/tax-product-connector-extension": "^1.0.0",
                 "spryker/transfer": "^3.27.0",
@@ -26186,9 +26184,9 @@
             ],
             "description": "Customer module",
             "support": {
-                "source": "https://github.com/spryker/customer/tree/7.50.0"
+                "source": "https://github.com/spryker/customer/tree/7.51.5"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-08-03T15:55:31+00:00"
         },
         {
             "name": "spryker/customer-access",
@@ -27304,16 +27302,16 @@
         },
         {
             "name": "spryker/discount",
-            "version": "9.32.0",
+            "version": "9.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/discount.git",
-                "reference": "ed4d7e273ed6d50d39f16141712859ac9f7b400f"
+                "reference": "833af3d4e77526156eb6913a5a867682d23839ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/discount/zipball/ed4d7e273ed6d50d39f16141712859ac9f7b400f",
-                "reference": "ed4d7e273ed6d50d39f16141712859ac9f7b400f",
+                "url": "https://api.github.com/repos/spryker/discount/zipball/833af3d4e77526156eb6913a5a867682d23839ef",
+                "reference": "833af3d4e77526156eb6913a5a867682d23839ef",
                 "shasum": ""
             },
             "require": {
@@ -27321,18 +27319,18 @@
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/cart-code-extension": "^1.1.0",
                 "spryker/cart-extension": "^1.0.0 || ^2.0.0 || ^4.0.0",
-                "spryker/currency": "^3.1.0",
+                "spryker/currency": "^3.1.0 || ^4.0.0",
                 "spryker/discount-extension": "^1.3.0",
                 "spryker/gui": "^3.45.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/log": "^3.0.0",
                 "spryker/messenger": "^3.0.0",
                 "spryker/money": "^2.0.0",
                 "spryker/product-option": "^6.0.0 || ^8.0.0",
                 "spryker/propel-orm": "^1.0.0",
                 "spryker/sales": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^10.0.0 || ^11.0.0",
-                "spryker/store": "^1.1.0",
+                "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.25.0",
                 "spryker/translator": "^1.1.0",
@@ -27376,9 +27374,9 @@
             ],
             "description": "Discount module",
             "support": {
-                "source": "https://github.com/spryker/discount/tree/9.32.0"
+                "source": "https://github.com/spryker/discount/tree/9.34.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-06-22T08:06:14+00:00"
         },
         {
             "name": "spryker/discount-calculation-connector",
@@ -27917,6 +27915,48 @@
             "time": "2022-05-16T14:55:23+00:00"
         },
         {
+            "name": "spryker/dynamic-entity-extension",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/dynamic-entity-extension.git",
+                "reference": "bf84f58deb3dc0135ded9e91e19d58c53e02fc34"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/dynamic-entity-extension/zipball/bf84f58deb3dc0135ded9e91e19d58c53e02fc34",
+                "reference": "bf84f58deb3dc0135ded9e91e19d58c53e02fc34",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/transfer": "^3.27.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "DynamicEntityExtension module",
+            "support": {
+                "source": "https://github.com/spryker/dynamic-entity-extension/tree/1.0.0"
+            },
+            "time": "2023-09-19T09:44:37+00:00"
+        },
+        {
             "name": "spryker/egulias",
             "version": "1.1.1",
             "source": {
@@ -28079,16 +28119,16 @@
         },
         {
             "name": "spryker/error-handler",
-            "version": "2.7.1",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/error-handler.git",
-                "reference": "b6aabea19f543e9255c95605956bbb94e3831cfb"
+                "reference": "a7df6c890b36982e0eaab1a65aa071d3c46c8236"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/error-handler/zipball/b6aabea19f543e9255c95605956bbb94e3831cfb",
-                "reference": "b6aabea19f543e9255c95605956bbb94e3831cfb",
+                "url": "https://api.github.com/repos/spryker/error-handler/zipball/a7df6c890b36982e0eaab1a65aa071d3c46c8236",
+                "reference": "a7df6c890b36982e0eaab1a65aa071d3c46c8236",
                 "shasum": ""
             },
             "require": {
@@ -28134,9 +28174,9 @@
             ],
             "description": "ErrorHandler module",
             "support": {
-                "source": "https://github.com/spryker/error-handler/tree/2.7.1"
+                "source": "https://github.com/spryker/error-handler/tree/2.9.0"
             },
-            "time": "2023-03-10T12:46:34+00:00"
+            "time": "2023-10-23T13:54:19+00:00"
         },
         {
             "name": "spryker/error-handler-extension",
@@ -28962,16 +29002,16 @@
         },
         {
             "name": "spryker/glossary",
-            "version": "3.13.0",
+            "version": "3.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/glossary.git",
-                "reference": "98b185a04e06ddca7bef62442038631dd61fa909"
+                "reference": "31968a9b30ccc6465903d4188af9d31568e56b64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/glossary/zipball/98b185a04e06ddca7bef62442038631dd61fa909",
-                "reference": "98b185a04e06ddca7bef62442038631dd61fa909",
+                "url": "https://api.github.com/repos/spryker/glossary/zipball/31968a9b30ccc6465903d4188af9d31568e56b64",
+                "reference": "31968a9b30ccc6465903d4188af9d31568e56b64",
                 "shasum": ""
             },
             "require": {
@@ -28980,7 +29020,7 @@
                 "spryker/gui": "^3.0.0",
                 "spryker/kernel": "^3.52.0",
                 "spryker/key-builder": "^1.0.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/messenger": "^3.0.0",
                 "spryker/messenger-extension": "^1.0.0",
                 "spryker/propel-orm": "^1.0.0",
@@ -28999,6 +29039,7 @@
                 "spryker/installer": "*",
                 "spryker/propel": "*",
                 "spryker/router": "*",
+                "spryker/store": "*",
                 "spryker/testify": "*",
                 "spryker/twig": "*",
                 "spryker/validator": "*",
@@ -29027,26 +29068,26 @@
             ],
             "description": "Glossary module",
             "support": {
-                "source": "https://github.com/spryker/glossary/tree/3.13.0"
+                "source": "https://github.com/spryker/glossary/tree/3.14.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/glossary-storage",
-            "version": "1.11.0",
+            "version": "1.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/glossary-storage.git",
-                "reference": "808a57eae521dd3e517e568fa498046d29063392"
+                "reference": "d0abc3e77bec5c1d1defa09b7e84d0e53cdf96cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/glossary-storage/zipball/808a57eae521dd3e517e568fa498046d29063392",
-                "reference": "808a57eae521dd3e517e568fa498046d29063392",
+                "url": "https://api.github.com/repos/spryker/glossary-storage/zipball/d0abc3e77bec5c1d1defa09b7e84d0e53cdf96cf",
+                "reference": "d0abc3e77bec5c1d1defa09b7e84d0e53cdf96cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
                 "spryker/event-behavior": "^1.1.0",
                 "spryker/glossary": "^3.7.0",
                 "spryker/kernel": "^3.30.0",
@@ -29062,9 +29103,12 @@
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/event": "*",
                 "spryker/propel": "*",
+                "spryker/publisher": "*",
                 "spryker/queue": "*",
+                "spryker/store": "*",
                 "spryker/testify": "*"
             },
             "suggest": {
@@ -29087,9 +29131,9 @@
             ],
             "description": "GlossaryStorage module",
             "support": {
-                "source": "https://github.com/spryker/glossary-storage/tree/1.11.0"
+                "source": "https://github.com/spryker/glossary-storage/tree/1.11.2"
             },
-            "time": "2022-06-21T18:18:41+00:00"
+            "time": "2023-10-18T17:03:23+00:00"
         },
         {
             "name": "spryker/glue-application",
@@ -29770,16 +29814,16 @@
         },
         {
             "name": "spryker/gui",
-            "version": "3.49.0",
+            "version": "3.51.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/gui.git",
-                "reference": "aed54705ec1480550842ff8db6c25dae5dd795d2"
+                "reference": "d510351d3827ee75bed94f2692461ae074f0d0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/gui/zipball/aed54705ec1480550842ff8db6c25dae5dd795d2",
-                "reference": "aed54705ec1480550842ff8db6c25dae5dd795d2",
+                "url": "https://api.github.com/repos/spryker/gui/zipball/d510351d3827ee75bed94f2692461ae074f0d0b2",
+                "reference": "d510351d3827ee75bed94f2692461ae074f0d0b2",
                 "shasum": ""
             },
             "require": {
@@ -29803,6 +29847,7 @@
                 "spryker/container": "*",
                 "spryker/propel": "*",
                 "spryker/silex": "*",
+                "spryker/store": "*",
                 "spryker/testify": "*"
             },
             "suggest": {
@@ -29827,26 +29872,81 @@
             ],
             "description": "Gui module",
             "support": {
-                "source": "https://github.com/spryker/gui/tree/3.49.0"
+                "source": "https://github.com/spryker/gui/tree/3.51.0"
             },
-            "time": "2023-03-13T18:17:58+00:00"
+            "time": "2023-09-22T10:20:19+00:00"
         },
         {
-            "name": "spryker/guzzle",
-            "version": "2.4.0",
+            "name": "spryker/gui-table",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/spryker/guzzle.git",
-                "reference": "f462fc17af7e1800b69b1c187296d8f2c5ce85f8"
+                "url": "https://github.com/spryker/gui-table.git",
+                "reference": "e07388841a67389b84f8d32a7b198b494b455642"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/guzzle/zipball/f462fc17af7e1800b69b1c187296d8f2c5ce85f8",
-                "reference": "f462fc17af7e1800b69b1c187296d8f2c5ce85f8",
+                "url": "https://api.github.com/repos/spryker/gui-table/zipball/e07388841a67389b84f8d32a7b198b494b455642",
+                "reference": "e07388841a67389b84f8d32a7b198b494b455642",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "^7.0.0",
+                "php": ">=8.0",
+                "spryker/application-extension": "^1.0.0",
+                "spryker/kernel": "^3.30.0",
+                "spryker/symfony": "^3.0.0",
+                "spryker/transfer": "^3.27.0",
+                "spryker/translator": "^1.1.0",
+                "spryker/twig": "^3.13.0",
+                "spryker/util-date-time": "^1.3.0",
+                "spryker/util-encoding": "^2.0.0",
+                "spryker/zed-ui": "^2.0.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/container": "*",
+                "spryker/testify": "*"
+            },
+            "suggest": {
+                "spryker/container": "If you want to use ApplicationPluginInterface"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "GuiTable module",
+            "support": {
+                "source": "https://github.com/spryker/gui-table/tree/2.1.2"
+            },
+            "time": "2023-04-19T13:38:54+00:00"
+        },
+        {
+            "name": "spryker/guzzle",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/guzzle.git",
+                "reference": "ed1d219086f6b8719d6b90d54bc9f12388ca9a4c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/guzzle/zipball/ed1d219086f6b8719d6b90d54bc9f12388ca9a4c",
+                "reference": "ed1d219086f6b8719d6b90d54bc9f12388ca9a4c",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.5.1",
                 "php": ">=8.0"
             },
             "type": "library",
@@ -29861,9 +29961,9 @@
             ],
             "description": "Guzzle module",
             "support": {
-                "source": "https://github.com/spryker/guzzle/tree/2.4.0"
+                "source": "https://github.com/spryker/guzzle/tree/2.4.1"
             },
-            "time": "2022-10-18T17:47:15+00:00"
+            "time": "2023-06-22T13:12:04+00:00"
         },
         {
             "name": "spryker/health-check",
@@ -30292,16 +30392,16 @@
         },
         {
             "name": "spryker/kernel",
-            "version": "3.71.1",
+            "version": "3.73.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/kernel.git",
-                "reference": "416f88b29771f598d2bd8c8a951fd1837f0fa158"
+                "reference": "9f22c67cf2b53eb5a8f201a0742317eeadc33c60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/kernel/zipball/416f88b29771f598d2bd8c8a951fd1837f0fa158",
-                "reference": "416f88b29771f598d2bd8c8a951fd1837f0fa158",
+                "url": "https://api.github.com/repos/spryker/kernel/zipball/9f22c67cf2b53eb5a8f201a0742317eeadc33c60",
+                "reference": "9f22c67cf2b53eb5a8f201a0742317eeadc33c60",
                 "shasum": ""
             },
             "require": {
@@ -30347,9 +30447,9 @@
             ],
             "description": "Kernel module",
             "support": {
-                "source": "https://github.com/spryker/kernel/tree/3.71.1"
+                "source": "https://github.com/spryker/kernel/tree/3.73.0"
             },
-            "time": "2023-02-01T16:35:54+00:00"
+            "time": "2023-06-13T10:42:20+00:00"
         },
         {
             "name": "spryker/key-builder",
@@ -30433,16 +30533,16 @@
         },
         {
             "name": "spryker/locale",
-            "version": "3.9.0",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/locale.git",
-                "reference": "08971b821d254eb996f3b37fb857759bc8bd4849"
+                "reference": "1ae0c8b8e97fc91dc442876023b2acfdf44d625c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/locale/zipball/08971b821d254eb996f3b37fb857759bc8bd4849",
-                "reference": "08971b821d254eb996f3b37fb857759bc8bd4849",
+                "url": "https://api.github.com/repos/spryker/locale/zipball/1ae0c8b8e97fc91dc442876023b2acfdf44d625c",
+                "reference": "1ae0c8b8e97fc91dc442876023b2acfdf44d625c",
                 "shasum": ""
             },
             "require": {
@@ -30453,7 +30553,8 @@
                 "spryker/kernel": "^3.52.0",
                 "spryker/locale-extension": "^1.0.0",
                 "spryker/propel-orm": "^1.8.0",
-                "spryker/transfer": "^3.25.0"
+                "spryker/transfer": "^3.27.0",
+                "spryker/willdurand-negotiation": "^1.0.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
@@ -30491,9 +30592,9 @@
             ],
             "description": "Locale module",
             "support": {
-                "source": "https://github.com/spryker/locale/tree/3.9.0"
+                "source": "https://github.com/spryker/locale/tree/3.10.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-10-13T11:36:58+00:00"
         },
         {
             "name": "spryker/locale-extension",
@@ -30543,16 +30644,16 @@
         },
         {
             "name": "spryker/log",
-            "version": "3.14.0",
+            "version": "3.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/log.git",
-                "reference": "2e35e47ce44b133dc197f43c3ab4b6a78d7ed6ae"
+                "reference": "ba336833734a71c5d99d0be2a517d8ba9fd66f29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/log/zipball/2e35e47ce44b133dc197f43c3ab4b6a78d7ed6ae",
-                "reference": "2e35e47ce44b133dc197f43c3ab4b6a78d7ed6ae",
+                "url": "https://api.github.com/repos/spryker/log/zipball/ba336833734a71c5d99d0be2a517d8ba9fd66f29",
+                "reference": "ba336833734a71c5d99d0be2a517d8ba9fd66f29",
                 "shasum": ""
             },
             "require": {
@@ -30560,7 +30661,7 @@
                 "psr/log": "^1.0.0",
                 "spryker/config": "^3.0.0",
                 "spryker/kernel": "^3.48.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/monolog": "^2.0.0",
                 "spryker/queue": "^0.3.0 || ^1.0.0",
                 "spryker/symfony": "^3.0.0",
@@ -30594,29 +30695,29 @@
             ],
             "description": "Log module",
             "support": {
-                "source": "https://github.com/spryker/log/tree/3.14.0"
+                "source": "https://github.com/spryker/log/tree/3.15.0"
             },
-            "time": "2023-03-29T12:45:08+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/mail",
-            "version": "4.10.0",
+            "version": "4.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/mail.git",
-                "reference": "56c2aaa9b7ff3983326e8b1d70ecbf6dba8da416"
+                "reference": "5657ea35eae740e4d2989db8664d2299502e30b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/mail/zipball/56c2aaa9b7ff3983326e8b1d70ecbf6dba8da416",
-                "reference": "56c2aaa9b7ff3983326e8b1d70ecbf6dba8da416",
+                "url": "https://api.github.com/repos/spryker/mail/zipball/5657ea35eae740e4d2989db8664d2299502e30b2",
+                "reference": "5657ea35eae740e4d2989db8664d2299502e30b2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "spryker/glossary": "^3.0.0",
                 "spryker/kernel": "^3.52.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/mail-extension": "^1.0.0",
                 "spryker/transfer": "^3.33.0",
                 "swiftmailer/swiftmailer": "^6.1.0"
@@ -30644,9 +30745,9 @@
             ],
             "description": "Mail module",
             "support": {
-                "source": "https://github.com/spryker/mail/tree/4.10.0"
+                "source": "https://github.com/spryker/mail/tree/4.11.0"
             },
-            "time": "2022-11-11T13:29:11+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/mail-extension",
@@ -30778,16 +30879,16 @@
         },
         {
             "name": "spryker/merchant",
-            "version": "3.6.0",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/merchant.git",
-                "reference": "6dcf160e3a7ebdd1e9d7551f216954aa7efb9e3d"
+                "reference": "20a87db02ca3b188c94bb0a934cfe2dc1f676659"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/merchant/zipball/6dcf160e3a7ebdd1e9d7551f216954aa7efb9e3d",
-                "reference": "6dcf160e3a7ebdd1e9d7551f216954aa7efb9e3d",
+                "url": "https://api.github.com/repos/spryker/merchant/zipball/20a87db02ca3b188c94bb0a934cfe2dc1f676659",
+                "reference": "20a87db02ca3b188c94bb0a934cfe2dc1f676659",
                 "shasum": ""
             },
             "require": {
@@ -30795,20 +30896,26 @@
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/cart-extension": "^4.0.0",
                 "spryker/checkout-extension": "^1.2.0",
-                "spryker/event": "^2.0.0",
+                "spryker/event": "^2.3.0",
                 "spryker/kernel": "^3.33.0",
-                "spryker/merchant-extension": "^1.1.0",
+                "spryker/log": "^3.0.0",
+                "spryker/merchant-extension": "^1.2.0",
+                "spryker/message-broker": "^1.5.0",
+                "spryker/message-broker-extension": "^1.0.0",
                 "spryker/price-product-merchant-relationship-storage-extension": "^1.0.0",
                 "spryker/propel-orm": "^1.0.0",
+                "spryker/publisher-extension": "^1.0.0",
                 "spryker/shopping-list-extension": "^1.2.0",
-                "spryker/store": "^1.1.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/store": "^1.20.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/url": "^3.0.0",
                 "spryker/util-text": "^1.0.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/propel": "*",
+                "spryker/ramsey-uuid": "*",
                 "spryker/testify": "*"
             },
             "type": "library",
@@ -30820,7 +30927,8 @@
             "autoload": {
                 "psr-4": {
                     "Spryker\\": "src/Spryker/",
-                    "SprykerTest\\Zed\\Merchant\\Helper\\": "tests/SprykerTest/Zed/Merchant/_support/Helper/"
+                    "SprykerTest\\Zed\\Merchant\\Helper\\": "tests/SprykerTest/Zed/Merchant/_support/Helper/",
+                    "SprykerTest\\AsyncApi\\Merchant\\Helper\\": "tests/SprykerTest/AsyncApi/Merchant/_support/Helper/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -30829,9 +30937,9 @@
             ],
             "description": "Merchant module",
             "support": {
-                "source": "https://github.com/spryker/merchant/tree/3.6.0"
+                "source": "https://github.com/spryker/merchant/tree/3.9.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-08-21T15:35:01+00:00"
         },
         {
             "name": "spryker/merchant-data-import",
@@ -30884,20 +30992,20 @@
         },
         {
             "name": "spryker/merchant-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/merchant-extension.git",
-                "reference": "a2e8d29c2fbabdbf6ebc7d33d8eb498223a883bf"
+                "reference": "30c2b54e176698d7b70da27061f5f94e4ba77470"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/merchant-extension/zipball/a2e8d29c2fbabdbf6ebc7d33d8eb498223a883bf",
-                "reference": "a2e8d29c2fbabdbf6ebc7d33d8eb498223a883bf",
+                "url": "https://api.github.com/repos/spryker/merchant-extension/zipball/30c2b54e176698d7b70da27061f5f94e4ba77470",
+                "reference": "30c2b54e176698d7b70da27061f5f94e4ba77470",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=8.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -30919,9 +31027,9 @@
             ],
             "description": "MerchantExtension module",
             "support": {
-                "source": "https://github.com/spryker/merchant-extension/tree/1.1.0"
+                "source": "https://github.com/spryker/merchant-extension/tree/1.2.0"
             },
-            "time": "2020-01-29T09:34:23+00:00"
+            "time": "2023-08-11T12:28:44+00:00"
         },
         {
             "name": "spryker/merchant-gui",
@@ -31028,6 +31136,219 @@
                 "source": "https://github.com/spryker/merchant-gui-extension/tree/1.1.0"
             },
             "time": "2020-04-08T15:48:06+00:00"
+        },
+        {
+            "name": "spryker/merchant-product",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/merchant-product.git",
+                "reference": "69ee765449bf2021de9a829fac8cececf0ebd241"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/merchant-product/zipball/69ee765449bf2021de9a829fac8cececf0ebd241",
+                "reference": "69ee765449bf2021de9a829fac8cececf0ebd241",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/acl-merchant-portal-extension": "^1.0.0",
+                "spryker/cart-extension": "^4.0.0",
+                "spryker/kernel": "^3.33.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
+                "spryker/merchant": "^3.0.0",
+                "spryker/product": "^6.0.0",
+                "spryker/product-extension": "^1.1.0",
+                "spryker/propel-orm": "^1.0.0",
+                "spryker/shopping-list-extension": "^1.4.0",
+                "spryker/symfony": "^3.0.0",
+                "spryker/transfer": "^3.27.0",
+                "spryker/util-encoding": "^2.0.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/container": "*",
+                "spryker/propel": "*",
+                "spryker/store": "*",
+                "spryker/testify": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/",
+                    "SprykerTest\\Zed\\MerchantProduct\\Helper\\": "tests/SprykerTest/Zed/MerchantProduct/_support/Helper/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "MerchantProduct module",
+            "support": {
+                "source": "https://github.com/spryker/merchant-product/tree/1.6.0"
+            },
+            "time": "2023-03-31T19:36:11+00:00"
+        },
+        {
+            "name": "spryker/merchant-product-approval",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/merchant-product-approval.git",
+                "reference": "001784d1cb5dcce83eba547485be0875265223be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/merchant-product-approval/zipball/001784d1cb5dcce83eba547485be0875265223be",
+                "reference": "001784d1cb5dcce83eba547485be0875265223be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "spryker/kernel": "^3.30.0",
+                "spryker/merchant": "^3.0.0",
+                "spryker/merchant-product": "^1.0.0",
+                "spryker/product-approval": "^1.0.0",
+                "spryker/product-extension": "^1.2.0",
+                "spryker/transfer": "^3.25.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/product": "*",
+                "spryker/propel": "*",
+                "spryker/testify": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "MerchantProductApproval module",
+            "support": {
+                "source": "https://github.com/spryker/merchant-product-approval/tree/1.0.0"
+            },
+            "time": "2022-02-11T12:49:43+00:00"
+        },
+        {
+            "name": "spryker/merchant-profile",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/merchant-profile.git",
+                "reference": "59498048281d61b062a6c6c6a7d755e4a6c000e9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/merchant-profile/zipball/59498048281d61b062a6c6c6a7d755e4a6c000e9",
+                "reference": "59498048281d61b062a6c6c6a7d755e4a6c000e9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/acl-merchant-portal-extension": "^1.0.0",
+                "spryker/country": "^3.0.0 || ^4.0.0",
+                "spryker/glossary": "^3.0.0",
+                "spryker/kernel": "^3.33.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
+                "spryker/merchant": "^3.0.0",
+                "spryker/merchant-extension": "^1.2.0",
+                "spryker/propel-orm": "^1.0.0",
+                "spryker/sales-extension": "^1.3.0",
+                "spryker/tax-app-extension": "^1.0.0",
+                "spryker/transfer": "^3.27.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/propel": "*",
+                "spryker/testify": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/",
+                    "SprykerTest\\Zed\\MerchantProfile\\Helper\\": "tests/SprykerTest/Zed/MerchantProfile/_support/Helper/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "MerchantProfile module",
+            "support": {
+                "source": "https://github.com/spryker/merchant-profile/tree/1.5.0"
+            },
+            "time": "2023-09-18T09:59:00+00:00"
+        },
+        {
+            "name": "spryker/merchant-profile-gui",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/merchant-profile-gui.git",
+                "reference": "3e891aef410426e266ed0d7a7663058964fa2f0b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/merchant-profile-gui/zipball/3e891aef410426e266ed0d7a7663058964fa2f0b",
+                "reference": "3e891aef410426e266ed0d7a7663058964fa2f0b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/country": "^3.0.0",
+                "spryker/glossary": "^3.0.0",
+                "spryker/gui": "^3.48.0",
+                "spryker/kernel": "^3.33.0",
+                "spryker/locale": "^3.0.0",
+                "spryker/merchant-gui-extension": "^1.0.0",
+                "spryker/merchant-profile": "^1.0.0",
+                "spryker/symfony": "^3.0.0",
+                "spryker/transfer": "^3.25.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "MerchantProfileGui module",
+            "support": {
+                "source": "https://github.com/spryker/merchant-profile-gui/tree/1.1.0"
+            },
+            "time": "2023-03-13T13:20:27+00:00"
         },
         {
             "name": "spryker/merchant-relationship",
@@ -31644,31 +31965,180 @@
             "time": "2019-02-06T10:10:03+00:00"
         },
         {
-            "name": "spryker/message-broker",
-            "version": "1.4.1",
+            "name": "spryker/merchant-stock",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/spryker/message-broker.git",
-                "reference": "f073764105de0473042fb66e137bae64345b286f"
+                "url": "https://github.com/spryker/merchant-stock.git",
+                "reference": "0c2781ab51a225a3925af50c7aa0686b861cc85e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/message-broker/zipball/f073764105de0473042fb66e137bae64345b286f",
-                "reference": "f073764105de0473042fb66e137bae64345b286f",
+                "url": "https://api.github.com/repos/spryker/merchant-stock/zipball/0c2781ab51a225a3925af50c7aa0686b861cc85e",
+                "reference": "0c2781ab51a225a3925af50c7aa0686b861cc85e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/acl-merchant-portal-extension": "^1.0.0",
+                "spryker/kernel": "^3.33.0",
+                "spryker/merchant": "^3.0.0",
+                "spryker/merchant-extension": "^1.2.0",
+                "spryker/propel-orm": "^1.0.0",
+                "spryker/stock": "^8.0.0",
+                "spryker/store": "^1.0.0",
+                "spryker/transfer": "^3.27.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/propel": "*",
+                "spryker/testify": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/",
+                    "SprykerTest\\Zed\\MerchantStock\\Helper\\": "tests/SprykerTest/Zed/MerchantStock/_support/Helper/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "MerchantStock module",
+            "support": {
+                "source": "https://github.com/spryker/merchant-stock/tree/1.2.0"
+            },
+            "time": "2023-08-11T12:28:44+00:00"
+        },
+        {
+            "name": "spryker/merchant-user",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/merchant-user.git",
+                "reference": "4a8d5300993d50358520e51e5c4496cb394131d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/merchant-user/zipball/4a8d5300993d50358520e51e5c4496cb394131d0",
+                "reference": "4a8d5300993d50358520e51e5c4496cb394131d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/acl-merchant-portal-extension": "^1.0.0",
+                "spryker/kernel": "^3.33.0",
+                "spryker/merchant": "^3.0.0",
+                "spryker/merchant-extension": "^1.1.0",
+                "spryker/merchant-user-extension": "^1.1.0",
+                "spryker/propel-orm": "^1.5.0",
+                "spryker/security-gui-extension": "^1.1.0",
+                "spryker/transfer": "^3.27.0",
+                "spryker/user": "^3.17.0",
+                "spryker/user-password-reset": "^1.0.0",
+                "spryker/util-text": "^1.3.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/merchant-profile": "*",
+                "spryker/propel": "*",
+                "spryker/testify": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/",
+                    "SprykerTest\\Zed\\MerchantUser\\Helper\\": "tests/SprykerTest/Zed/MerchantUser/_support/Helper/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "MerchantUser module",
+            "support": {
+                "source": "https://github.com/spryker/merchant-user/tree/1.4.0"
+            },
+            "time": "2023-03-10T14:11:16+00:00"
+        },
+        {
+            "name": "spryker/merchant-user-extension",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/merchant-user-extension.git",
+                "reference": "23de6843796c7c303f79dafdbb38e3dd8348bd4f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/merchant-user-extension/zipball/23de6843796c7c303f79dafdbb38e3dd8348bd4f",
+                "reference": "23de6843796c7c303f79dafdbb38e3dd8348bd4f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "MerchantUserExtension module",
+            "support": {
+                "source": "https://github.com/spryker/merchant-user-extension/tree/1.1.0"
+            },
+            "time": "2021-12-10T09:14:37+00:00"
+        },
+        {
+            "name": "spryker/message-broker",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/message-broker.git",
+                "reference": "39bca2ed0ad89f3168b667188a2b79e5e4bcadc8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/message-broker/zipball/39bca2ed0ad89f3168b667188a2b79e5e4bcadc8",
+                "reference": "39bca2ed0ad89f3168b667188a2b79e5e4bcadc8",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/log": "^3.0.0",
-                "spryker/message-broker-extension": "^1.1.0",
+                "spryker/message-broker-extension": "^1.2.0",
                 "spryker/monolog": "^2.0.0",
                 "spryker/symfony": "^3.10.0",
                 "spryker/transfer": "^3.25.0",
                 "spryker/util-encoding": "^1.0.0 || ^2.0.0"
             },
             "require-dev": {
-                "spryker-sdk/async-api": "^0.2.0",
+                "spryker-sdk/async-api": "^0.3.0",
                 "spryker/application": "*",
                 "spryker/code-sniffer": "*",
                 "spryker/console": "*",
@@ -31676,6 +32146,7 @@
                 "spryker/event-dispatcher": "*",
                 "spryker/message-broker-aws": "*",
                 "spryker/ramsey-uuid": "*",
+                "spryker/store": "*",
                 "spryker/testify": "*"
             },
             "suggest": {
@@ -31699,9 +32170,9 @@
             ],
             "description": "MessageBroker module",
             "support": {
-                "source": "https://github.com/spryker/message-broker/tree/1.4.1"
+                "source": "https://github.com/spryker/message-broker/tree/1.9.0"
             },
-            "time": "2023-02-08T11:59:50+00:00"
+            "time": "2023-08-31T11:27:42+00:00"
         },
         {
             "name": "spryker/message-broker-aws",
@@ -31765,16 +32236,16 @@
         },
         {
             "name": "spryker/message-broker-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/message-broker-extension.git",
-                "reference": "8360ac910ec5458e47ce4e3d6600073111d57298"
+                "reference": "c7fee41058388c635c07fd3787b451a2736340d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/message-broker-extension/zipball/8360ac910ec5458e47ce4e3d6600073111d57298",
-                "reference": "8360ac910ec5458e47ce4e3d6600073111d57298",
+                "url": "https://api.github.com/repos/spryker/message-broker-extension/zipball/c7fee41058388c635c07fd3787b451a2736340d1",
+                "reference": "c7fee41058388c635c07fd3787b451a2736340d1",
                 "shasum": ""
             },
             "require": {
@@ -31806,9 +32277,9 @@
             ],
             "description": "MessageBrokerExtension module",
             "support": {
-                "source": "https://github.com/spryker/message-broker-extension/tree/1.1.0"
+                "source": "https://github.com/spryker/message-broker-extension/tree/1.2.0"
             },
-            "time": "2022-12-23T11:50:03+00:00"
+            "time": "2023-07-21T13:09:09+00:00"
         },
         {
             "name": "spryker/messenger",
@@ -31906,25 +32377,25 @@
         },
         {
             "name": "spryker/money",
-            "version": "2.11.0",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/money.git",
-                "reference": "0ecf3313fbd22179e3df82af00da376c96619b55"
+                "reference": "976e44e6b0cb7af9178ab40861b568fab4dc73da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/money/zipball/0ecf3313fbd22179e3df82af00da376c96619b55",
-                "reference": "0ecf3313fbd22179e3df82af00da376c96619b55",
+                "url": "https://api.github.com/repos/spryker/money/zipball/976e44e6b0cb7af9178ab40861b568fab4dc73da",
+                "reference": "976e44e6b0cb7af9178ab40861b568fab4dc73da",
                 "shasum": ""
             },
             "require": {
                 "moneyphp/money": "^3.0.0",
                 "php": ">=8.0",
-                "spryker/currency": "^3.1.0",
+                "spryker/currency": "^3.2.0 || ^4.0.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
-                "spryker/store": "^1.1.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
+                "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.25.0",
                 "spryker/twig-extension": "^1.0.0"
@@ -31936,6 +32407,7 @@
                 "spryker/propel": "*",
                 "spryker/session": "*",
                 "spryker/silex": "*",
+                "spryker/storage": "*",
                 "spryker/testify": "*",
                 "spryker/twig": "*"
             },
@@ -31961,9 +32433,9 @@
             ],
             "description": "Money module",
             "support": {
-                "source": "https://github.com/spryker/money/tree/2.11.0"
+                "source": "https://github.com/spryker/money/tree/2.12.0"
             },
-            "time": "2023-01-24T16:01:46+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/money-gui",
@@ -32015,23 +32487,23 @@
         },
         {
             "name": "spryker/monitoring",
-            "version": "2.7.0",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/monitoring.git",
-                "reference": "88ecb7e9d6d1c223d924610d42840b948695afef"
+                "reference": "d4cabe1940b4159a3563ef6460f4b014ce4d24e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/monitoring/zipball/88ecb7e9d6d1c223d924610d42840b948695afef",
-                "reference": "88ecb7e9d6d1c223d924610d42840b948695afef",
+                "url": "https://api.github.com/repos/spryker/monitoring/zipball/d4cabe1940b4159a3563ef6460f4b014ce4d24e2",
+                "reference": "d4cabe1940b4159a3563ef6460f4b014ce4d24e2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "spryker/event-dispatcher-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/monitoring-extension": "^1.0.0",
                 "spryker/store": "^1.0.0",
                 "spryker/symfony": "^3.5.0",
@@ -32065,9 +32537,9 @@
             ],
             "description": "Monitoring module",
             "support": {
-                "source": "https://github.com/spryker/monitoring/tree/2.7.0"
+                "source": "https://github.com/spryker/monitoring/tree/2.8.0"
             },
-            "time": "2023-01-24T16:01:46+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/monitoring-extension",
@@ -33615,16 +34087,16 @@
         },
         {
             "name": "spryker/oms",
-            "version": "11.25.0",
+            "version": "11.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/oms.git",
-                "reference": "6a0d263d50fc8e86bb339ff4b6f2a9f648ff8774"
+                "reference": "59b5c707d9d7fde1c57fed0ded576441f5e2d4aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/oms/zipball/6a0d263d50fc8e86bb339ff4b6f2a9f648ff8774",
-                "reference": "6a0d263d50fc8e86bb339ff4b6f2a9f648ff8774",
+                "url": "https://api.github.com/repos/spryker/oms/zipball/59b5c707d9d7fde1c57fed0ded576441f5e2d4aa",
+                "reference": "59b5c707d9d7fde1c57fed0ded576441f5e2d4aa",
                 "shasum": ""
             },
             "require": {
@@ -33654,8 +34126,10 @@
                 "spryker/application": "*",
                 "spryker/checkout": "*",
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/customer": "*",
                 "spryker/sales-payment": "*",
+                "spryker/shipment": "*",
                 "spryker/testify": "*"
             },
             "suggest": {
@@ -33679,9 +34153,9 @@
             ],
             "description": "Oms module",
             "support": {
-                "source": "https://github.com/spryker/oms/tree/11.25.0"
+                "source": "https://github.com/spryker/oms/tree/11.27.0"
             },
-            "time": "2023-03-29T08:35:49+00:00"
+            "time": "2023-08-21T15:35:01+00:00"
         },
         {
             "name": "spryker/oms-discount-connector",
@@ -34679,20 +35153,20 @@
         },
         {
             "name": "spryker/price",
-            "version": "5.6.2",
+            "version": "5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/price.git",
-                "reference": "4f7af4401db9ae608cee3e5d5821ac36456713f3"
+                "reference": "bf9bbda8ea062279e70011889d215e1197a7393d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/price/zipball/4f7af4401db9ae608cee3e5d5821ac36456713f3",
-                "reference": "4f7af4401db9ae608cee3e5d5821ac36456713f3",
+                "url": "https://api.github.com/repos/spryker/price/zipball/bf9bbda8ea062279e70011889d215e1197a7393d",
+                "reference": "bf9bbda8ea062279e70011889d215e1197a7393d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
+                "php": ">=8.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/price-extension": "^1.0.0",
                 "spryker/quote": "^1.2.0 || ^2.0.0",
@@ -34701,8 +35175,13 @@
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/propel": "*",
+                "spryker/session": "*",
                 "spryker/silex": "*",
+                "spryker/storage": "*",
+                "spryker/store": "*",
+                "spryker/store-extension": "*",
                 "spryker/testify": "*",
                 "spryker/twig": "*"
             },
@@ -34728,9 +35207,9 @@
             ],
             "description": "Price module",
             "support": {
-                "source": "https://github.com/spryker/price/tree/5.6.2"
+                "source": "https://github.com/spryker/price/tree/5.7.0"
             },
-            "time": "2020-09-01T11:14:46+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/price-cart-connector",
@@ -34920,22 +35399,22 @@
         },
         {
             "name": "spryker/price-product",
-            "version": "4.40.0",
+            "version": "4.43.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/price-product.git",
-                "reference": "42a0deeda4c5ee45651284983879b50886386b52"
+                "reference": "e623a4cccc82741cb814b76fa49b5e375c670f1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/price-product/zipball/42a0deeda4c5ee45651284983879b50886386b52",
-                "reference": "42a0deeda4c5ee45651284983879b50886386b52",
+                "url": "https://api.github.com/repos/spryker/price-product/zipball/e623a4cccc82741cb814b76fa49b5e375c670f1e",
+                "reference": "e623a4cccc82741cb814b76fa49b5e375c670f1e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
-                "spryker/currency": "^3.10.0",
+                "spryker/currency": "^3.10.0 || ^4.0.0",
                 "spryker/event": "^1.0.0 || ^2.0.0",
                 "spryker/kernel": "^3.33.0",
                 "spryker/log": "^3.7.0",
@@ -34960,6 +35439,8 @@
                 "spryker/price-product-storage": "*",
                 "spryker/propel": "*",
                 "spryker/session": "*",
+                "spryker/storage": "*",
+                "spryker/store-extension": "*",
                 "spryker/testify": "*",
                 "spryker/wishlist": "*"
             },
@@ -34984,9 +35465,9 @@
             ],
             "description": "PriceProduct module",
             "support": {
-                "source": "https://github.com/spryker/price-product/tree/4.40.0"
+                "source": "https://github.com/spryker/price-product/tree/4.43.0"
             },
-            "time": "2023-03-17T11:55:03+00:00"
+            "time": "2023-09-20T10:37:58+00:00"
         },
         {
             "name": "spryker/price-product-data-import",
@@ -35614,22 +36095,22 @@
         },
         {
             "name": "spryker/price-product-volume",
-            "version": "3.3.1",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/price-product-volume.git",
-                "reference": "5baa6882b173f759af1f43a159af5da76bf3c1b2"
+                "reference": "ab9dd571727f441f2eb2619c164dfe2896e0c9dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/price-product-volume/zipball/5baa6882b173f759af1f43a159af5da76bf3c1b2",
-                "reference": "5baa6882b173f759af1f43a159af5da76bf3c1b2",
+                "url": "https://api.github.com/repos/spryker/price-product-volume/zipball/ab9dd571727f441f2eb2619c164dfe2896e0c9dc",
+                "reference": "ab9dd571727f441f2eb2619c164dfe2896e0c9dc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/price-product": "^2.11.0 || ^4.0.0",
                 "spryker/price-product-extension": "^1.5.0",
                 "spryker/price-product-storage": "^2.17.0 || ^4.6.0",
@@ -35641,7 +36122,9 @@
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/propel": "*",
+                "spryker/store": "*",
                 "spryker/testify": "*"
             },
             "type": "library",
@@ -35661,9 +36144,9 @@
             ],
             "description": "PriceProductVolume module",
             "support": {
-                "source": "https://github.com/spryker/price-product-volume/tree/3.3.1"
+                "source": "https://github.com/spryker/price-product-volume/tree/3.4.0"
             },
-            "time": "2022-04-15T13:47:42+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/price-product-volume-gui",
@@ -35762,16 +36245,16 @@
         },
         {
             "name": "spryker/product",
-            "version": "6.34.0",
+            "version": "6.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product.git",
-                "reference": "1593ccceb47360b774df716af8032ebd0732187c"
+                "reference": "4e4cb5700ec4340d9a3cc87c350fe4d40e044b33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product/zipball/1593ccceb47360b774df716af8032ebd0732187c",
-                "reference": "1593ccceb47360b774df716af8032ebd0732187c",
+                "url": "https://api.github.com/repos/spryker/product/zipball/4e4cb5700ec4340d9a3cc87c350fe4d40e044b33",
+                "reference": "4e4cb5700ec4340d9a3cc87c350fe4d40e044b33",
                 "shasum": ""
             },
             "require": {
@@ -35821,9 +36304,9 @@
             ],
             "description": "Product module",
             "support": {
-                "source": "https://github.com/spryker/product/tree/6.34.0"
+                "source": "https://github.com/spryker/product/tree/6.37.0"
             },
-            "time": "2023-04-05T10:01:03+00:00"
+            "time": "2023-08-11T07:36:13+00:00"
         },
         {
             "name": "spryker/product-abstract-data-feed",
@@ -36218,26 +36701,81 @@
             "time": "2018-07-24T08:04:43+00:00"
         },
         {
-            "name": "spryker/product-attribute",
-            "version": "1.10.0",
+            "name": "spryker/product-approval",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/spryker/product-attribute.git",
-                "reference": "d8dd5bdf32cd6be8bea4ae0e14cab2f653295ea9"
+                "url": "https://github.com/spryker/product-approval.git",
+                "reference": "2301ee8795d7c7f97560f8eed7623cded0f5fb72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-attribute/zipball/d8dd5bdf32cd6be8bea4ae0e14cab2f653295ea9",
-                "reference": "d8dd5bdf32cd6be8bea4ae0e14cab2f653295ea9",
+                "url": "https://api.github.com/repos/spryker/product-approval/zipball/2301ee8795d7c7f97560f8eed7623cded0f5fb72",
+                "reference": "2301ee8795d7c7f97560f8eed7623cded0f5fb72",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
+                "spryker/cart-extension": "^4.0.0",
+                "spryker/checkout-extension": "^1.2.0",
+                "spryker/kernel": "^3.30.0",
+                "spryker/messenger": "^3.0.0",
+                "spryker/product": "^6.27.0",
+                "spryker/product-extension": "^1.4.0",
+                "spryker/product-page-search-extension": "^1.6.0",
+                "spryker/product-storage-extension": "^1.7.0",
+                "spryker/shopping-list-extension": "^1.1.0",
+                "spryker/transfer": "^3.25.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/propel": "*",
+                "spryker/testify": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "ProductApproval module",
+            "support": {
+                "source": "https://github.com/spryker/product-approval/tree/1.1.1"
+            },
+            "time": "2023-10-06T09:11:06+00:00"
+        },
+        {
+            "name": "spryker/product-attribute",
+            "version": "1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/product-attribute.git",
+                "reference": "9e03d5a563f70478de276c24db8f900495c12774"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/product-attribute/zipball/9e03d5a563f70478de276c24db8f900495c12774",
+                "reference": "9e03d5a563f70478de276c24db8f900495c12774",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/glossary": "^3.8.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/product": "^5.2.0 || ^6.0.0",
                 "spryker/propel-orm": "^1.2.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/util-encoding": "^2.0.0",
                 "spryker/util-sanitize-xss": "^1.0.0",
                 "spryker/zed-request": "^3.4.0"
@@ -36265,9 +36803,9 @@
             ],
             "description": "ProductAttribute module",
             "support": {
-                "source": "https://github.com/spryker/product-attribute/tree/1.10.0"
+                "source": "https://github.com/spryker/product-attribute/tree/1.13.0"
             },
-            "time": "2022-01-04T12:43:20+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/product-attribute-gui",
@@ -36926,16 +37464,16 @@
         },
         {
             "name": "spryker/product-category",
-            "version": "4.20.0",
+            "version": "4.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-category.git",
-                "reference": "4e0941db2e2e9e4a9a73ff958b881dc1a642c488"
+                "reference": "7f0e199369cb871c5693df4d66be36886f4cf28a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-category/zipball/4e0941db2e2e9e4a9a73ff958b881dc1a642c488",
-                "reference": "4e0941db2e2e9e4a9a73ff958b881dc1a642c488",
+                "url": "https://api.github.com/repos/spryker/product-category/zipball/7f0e199369cb871c5693df4d66be36886f4cf28a",
+                "reference": "7f0e199369cb871c5693df4d66be36886f4cf28a",
                 "shasum": ""
             },
             "require": {
@@ -36947,7 +37485,7 @@
                 "spryker/event": "^1.0.0 || ^2.3.0",
                 "spryker/gui": "^3.45.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/product": "^5.0.0 || ^6.0.0",
                 "spryker/product-extension": "^1.3.0",
                 "spryker/propel-orm": "^1.0.0",
@@ -36959,7 +37497,9 @@
                 "spryker/application": "*",
                 "spryker/code-sniffer": "*",
                 "spryker/config": "*",
+                "spryker/container": "*",
                 "spryker/propel": "^3.0.0",
+                "spryker/store": "*",
                 "spryker/testify": "*",
                 "spryker/zed-navigation": "*"
             },
@@ -36982,9 +37522,9 @@
             ],
             "description": "ProductCategory module",
             "support": {
-                "source": "https://github.com/spryker/product-category/tree/4.20.0"
+                "source": "https://github.com/spryker/product-category/tree/4.21.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/product-category-filter",
@@ -38700,31 +39240,33 @@
         },
         {
             "name": "spryker/product-image",
-            "version": "3.14.0",
+            "version": "3.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-image.git",
-                "reference": "6695e407372cafe53c4f611af97975e45d09728c"
+                "reference": "ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-image/zipball/6695e407372cafe53c4f611af97975e45d09728c",
-                "reference": "6695e407372cafe53c4f611af97975e45d09728c",
+                "url": "https://api.github.com/repos/spryker/product-image/zipball/ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3",
+                "reference": "ee8b04fd065a58fc74cd5bd0ed307ee50810f8c3",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/product": "^5.0.0 || ^6.0.0",
                 "spryker/product-extension": "^1.4.0",
                 "spryker/propel-orm": "^1.0.0",
-                "spryker/transfer": "^3.25.0"
+                "spryker/transfer": "^3.27.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/propel": "*",
+                "spryker/store": "*",
                 "spryker/testify": "*"
             },
             "type": "library",
@@ -38745,9 +39287,9 @@
             ],
             "description": "ProductImage module",
             "support": {
-                "source": "https://github.com/spryker/product-image/tree/3.14.0"
+                "source": "https://github.com/spryker/product-image/tree/3.17.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-07-17T12:04:54+00:00"
         },
         {
             "name": "spryker/product-image-cart-connector",
@@ -40045,6 +40587,128 @@
             "time": "2021-07-06T13:27:56+00:00"
         },
         {
+            "name": "spryker/product-merchant-portal-gui",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/product-merchant-portal-gui.git",
+                "reference": "951815112e9daf3fa1478b074e37737b6d41723c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/product-merchant-portal-gui/zipball/951815112e9daf3fa1478b074e37737b6d41723c",
+                "reference": "951815112e9daf3fa1478b074e37737b6d41723c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/acl-merchant-portal-extension": "^1.0.0",
+                "spryker/category": "^5.0.0",
+                "spryker/currency": "^3.0.0",
+                "spryker/decimal-object": "^1.0.0",
+                "spryker/gui": "^3.48.0",
+                "spryker/gui-table": "^2.0.0",
+                "spryker/kernel": "^3.51.0",
+                "spryker/laminas": "^1.0.0",
+                "spryker/locale": "^3.0.0",
+                "spryker/merchant-product": "^1.0.0",
+                "spryker/merchant-product-approval": "^1.0.0",
+                "spryker/merchant-stock": "^1.0.0",
+                "spryker/merchant-user": "^1.0.0",
+                "spryker/money": "^2.0.0",
+                "spryker/oms": "^11.7.0",
+                "spryker/price-product": "^4.35.0",
+                "spryker/price-product-volume": "^3.3.0",
+                "spryker/product": "^6.25.0",
+                "spryker/product-approval": "^1.0.0",
+                "spryker/product-attribute": "^1.8.0",
+                "spryker/product-category": "^4.6.0",
+                "spryker/product-image": "^3.0.0",
+                "spryker/product-merchant-portal-gui-extension": "^1.1.0",
+                "spryker/product-offer-merchant-portal-gui-extension": "^1.0.0",
+                "spryker/product-validity": "^1.0.0",
+                "spryker/propel-orm": "^1.0.0",
+                "spryker/store": "^1.1.0",
+                "spryker/symfony": "^3.0.0",
+                "spryker/transfer": "^3.27.0",
+                "spryker/translator": "^1.1.0",
+                "spryker/util-encoding": "^2.0.0",
+                "spryker/zed-ui": "^2.1.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/propel": "*",
+                "spryker/testify": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "ProductMerchantPortalGui module",
+            "support": {
+                "source": "https://github.com/spryker/product-merchant-portal-gui/tree/3.3.0"
+            },
+            "time": "2023-03-13T13:20:27+00:00"
+        },
+        {
+            "name": "spryker/product-merchant-portal-gui-extension",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/product-merchant-portal-gui-extension.git",
+                "reference": "a86b637633bd234553af965a856d9a030852dfae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/product-merchant-portal-gui-extension/zipball/a86b637633bd234553af965a856d9a030852dfae",
+                "reference": "a86b637633bd234553af965a856d9a030852dfae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/gui-table": "*",
+                "spryker/symfony": "*"
+            },
+            "suggest": {
+                "spryker/gui-table": "If you want to use GuiTableConfigurationBuilderInterface for expander plugins.",
+                "spryker/symfony": "If you want to use ProductMerchantPortalGui form expander plugins."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "ProductMerchantPortalGuiExtension module",
+            "support": {
+                "source": "https://github.com/spryker/product-merchant-portal-gui-extension/tree/1.1.0"
+            },
+            "time": "2022-04-15T13:47:42+00:00"
+        },
+        {
             "name": "spryker/product-new",
             "version": "1.4.0",
             "source": {
@@ -40147,31 +40811,77 @@
             "time": "2022-04-26T16:30:57+00:00"
         },
         {
-            "name": "spryker/product-option",
-            "version": "8.14.0",
+            "name": "spryker/product-offer-merchant-portal-gui-extension",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/spryker/product-option.git",
-                "reference": "4ec7d6a38078716cd6e173dfa55b3cd585d7b4b7"
+                "url": "https://github.com/spryker/product-offer-merchant-portal-gui-extension.git",
+                "reference": "dbc87a86d5cc5f418fc468ac2490a661beb6b5f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-option/zipball/4ec7d6a38078716cd6e173dfa55b3cd585d7b4b7",
-                "reference": "4ec7d6a38078716cd6e173dfa55b3cd585d7b4b7",
+                "url": "https://api.github.com/repos/spryker/product-offer-merchant-portal-gui-extension/zipball/dbc87a86d5cc5f418fc468ac2490a661beb6b5f7",
+                "reference": "dbc87a86d5cc5f418fc468ac2490a661beb6b5f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/transfer": "^3.27.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/symfony": "*"
+            },
+            "suggest": {
+                "spryker/symfony": "If you want to use form expander plugins."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "ProductOfferMerchantPortalGuiExtension module",
+            "support": {
+                "source": "https://github.com/spryker/product-offer-merchant-portal-gui-extension/tree/1.1.0"
+            },
+            "time": "2023-09-12T13:38:42+00:00"
+        },
+        {
+            "name": "spryker/product-option",
+            "version": "8.15.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/product-option.git",
+                "reference": "251fea2cef43316399f0c726cd0009dd3cbd1c90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/product-option/zipball/251fea2cef43316399f0c726cd0009dd3cbd1c90",
+                "reference": "251fea2cef43316399f0c726cd0009dd3cbd1c90",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/calculation-extension": "^1.1.0",
-                "spryker/country": "^3.0.0",
-                "spryker/currency": "^3.0.0",
+                "spryker/country": "^3.0.0 || ^4.0.0",
+                "spryker/currency": "^3.2.0 || ^4.0.0",
                 "spryker/event": "^2.1.0",
                 "spryker/glossary": "^3.0.0",
                 "spryker/gui": "^3.33.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/key-builder": "^1.0.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/money": "^2.4.0",
                 "spryker/price": "^5.0.0",
                 "spryker/product": "^5.0.0 || ^6.0.0",
@@ -40231,9 +40941,9 @@
             ],
             "description": "ProductOption module",
             "support": {
-                "source": "https://github.com/spryker/product-option/tree/8.14.0"
+                "source": "https://github.com/spryker/product-option/tree/8.15.2"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-05-05T18:20:59+00:00"
         },
         {
             "name": "spryker/product-option-cart-connector",
@@ -41679,16 +42389,16 @@
         },
         {
             "name": "spryker/product-search",
-            "version": "5.18.0",
+            "version": "5.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-search.git",
-                "reference": "d50cd9a8bed063b405a49b549d921cde79d504b4"
+                "reference": "0eef6daa5503d6375585b0304d35c9819a48e0ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-search/zipball/d50cd9a8bed063b405a49b549d921cde79d504b4",
-                "reference": "d50cd9a8bed063b405a49b549d921cde79d504b4",
+                "url": "https://api.github.com/repos/spryker/product-search/zipball/0eef6daa5503d6375585b0304d35c9819a48e0ed",
+                "reference": "0eef6daa5503d6375585b0304d35c9819a48e0ed",
                 "shasum": ""
             },
             "require": {
@@ -41700,7 +42410,7 @@
                 "spryker/gui": "^3.33.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/key-builder": "^1.1.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/product": "^5.0.0 || ^6.0.0",
                 "spryker/product-extension": "^1.3.0",
                 "spryker/product-page-search-extension": "^1.1.0",
@@ -41740,9 +42450,9 @@
             ],
             "description": "ProductSearch module",
             "support": {
-                "source": "https://github.com/spryker/product-search/tree/5.18.0"
+                "source": "https://github.com/spryker/product-search/tree/5.19.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/product-search-config-storage",
@@ -42047,16 +42757,16 @@
         },
         {
             "name": "spryker/product-storage",
-            "version": "1.36.2",
+            "version": "1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-storage.git",
-                "reference": "cb7153f382a17f181ce00ddcdb8058b1f2ec1a03"
+                "reference": "424ff5abad1843729079dfb563cd71a97cf134d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-storage/zipball/cb7153f382a17f181ce00ddcdb8058b1f2ec1a03",
-                "reference": "cb7153f382a17f181ce00ddcdb8058b1f2ec1a03",
+                "url": "https://api.github.com/repos/spryker/product-storage/zipball/424ff5abad1843729079dfb563cd71a97cf134d1",
+                "reference": "424ff5abad1843729079dfb563cd71a97cf134d1",
                 "shasum": ""
             },
             "require": {
@@ -42064,7 +42774,7 @@
                 "spryker/event-behavior": "^1.10.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/laminas": "^1.0.0",
-                "spryker/locale": "^3.1.0",
+                "spryker/locale": "^3.1.0 || ^4.0.0",
                 "spryker/product": "^5.5.0 || ^6.0.0",
                 "spryker/product-storage-extension": "^1.7.0",
                 "spryker/propel-orm": "^1.5.0",
@@ -42080,6 +42790,7 @@
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/event": "*",
                 "spryker/product-attribute": "*",
                 "spryker/propel": "*",
@@ -42108,9 +42819,9 @@
             ],
             "description": "ProductStorage module",
             "support": {
-                "source": "https://github.com/spryker/product-storage/tree/1.36.2"
+                "source": "https://github.com/spryker/product-storage/tree/1.38.0"
             },
-            "time": "2023-03-14T10:53:17+00:00"
+            "time": "2023-06-05T10:22:03+00:00"
         },
         {
             "name": "spryker/product-storage-extension",
@@ -42206,20 +42917,21 @@
         },
         {
             "name": "spryker/product-validity",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/product-validity.git",
-                "reference": "eb72811d155188689bb810db3dc8ec6e1e48cf6d"
+                "reference": "1f697baf8fe097b9406f86122d503514f009eaf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/product-validity/zipball/eb72811d155188689bb810db3dc8ec6e1e48cf6d",
-                "reference": "eb72811d155188689bb810db3dc8ec6e1e48cf6d",
+                "url": "https://api.github.com/repos/spryker/product-validity/zipball/1f697baf8fe097b9406f86122d503514f009eaf4",
+                "reference": "1f697baf8fe097b9406f86122d503514f009eaf4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
+                "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/product": "^6.0.0",
                 "spryker/product-extension": "^1.3.0",
@@ -42249,9 +42961,9 @@
             ],
             "description": "ProductValidity module",
             "support": {
-                "source": "https://github.com/spryker/product-validity/tree/1.2.0"
+                "source": "https://github.com/spryker/product-validity/tree/1.3.0"
             },
-            "time": "2022-02-22T13:01:19+00:00"
+            "time": "2023-03-10T14:11:16+00:00"
         },
         {
             "name": "spryker/products-categories-resource-relationship",
@@ -42400,16 +43112,16 @@
         },
         {
             "name": "spryker/propel",
-            "version": "3.36.0",
+            "version": "3.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/propel.git",
-                "reference": "5918e7d62375322d1ef3d7bcef118f958fe41878"
+                "reference": "26b4e6b523f8411b86fb59e02f80016111e63529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/propel/zipball/5918e7d62375322d1ef3d7bcef118f958fe41878",
-                "reference": "5918e7d62375322d1ef3d7bcef118f958fe41878",
+                "url": "https://api.github.com/repos/spryker/propel/zipball/26b4e6b523f8411b86fb59e02f80016111e63529",
+                "reference": "26b4e6b523f8411b86fb59e02f80016111e63529",
                 "shasum": ""
             },
             "require": {
@@ -42456,22 +43168,22 @@
             ],
             "description": "Propel module",
             "support": {
-                "source": "https://github.com/spryker/propel/tree/3.36.0"
+                "source": "https://github.com/spryker/propel/tree/3.38.0"
             },
-            "time": "2023-02-09T09:31:17+00:00"
+            "time": "2023-04-18T12:08:37+00:00"
         },
         {
             "name": "spryker/propel-orm",
-            "version": "1.18.0",
+            "version": "1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/propel-orm.git",
-                "reference": "4849ba4c5aad89a2c9f258c9b419f87cb4763f43"
+                "reference": "aeb6819ff5fc80fb6d6447c9abc7f11c911eb1d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/propel-orm/zipball/4849ba4c5aad89a2c9f258c9b419f87cb4763f43",
-                "reference": "4849ba4c5aad89a2c9f258c9b419f87cb4763f43",
+                "url": "https://api.github.com/repos/spryker/propel-orm/zipball/aeb6819ff5fc80fb6d6447c9abc7f11c911eb1d8",
+                "reference": "aeb6819ff5fc80fb6d6447c9abc7f11c911eb1d8",
                 "shasum": ""
             },
             "require": {
@@ -42506,9 +43218,9 @@
             ],
             "description": "PropelOrm module",
             "support": {
-                "source": "https://github.com/spryker/propel-orm/tree/1.18.0"
+                "source": "https://github.com/spryker/propel-orm/tree/1.19.0"
             },
-            "time": "2023-02-09T09:31:17+00:00"
+            "time": "2023-04-18T11:16:52+00:00"
         },
         {
             "name": "spryker/propel-orm-extension",
@@ -43004,29 +43716,29 @@
         },
         {
             "name": "spryker/quote",
-            "version": "2.17.0",
+            "version": "2.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/quote.git",
-                "reference": "7f7c54fa77fde959d3e820fd36ffbce7a49d23a2"
+                "reference": "e577815ae7bbe6e43f81fd657b3af92a19d88e2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/quote/zipball/7f7c54fa77fde959d3e820fd36ffbce7a49d23a2",
-                "reference": "7f7c54fa77fde959d3e820fd36ffbce7a49d23a2",
+                "url": "https://api.github.com/repos/spryker/quote/zipball/e577815ae7bbe6e43f81fd657b3af92a19d88e2e",
+                "reference": "e577815ae7bbe6e43f81fd657b3af92a19d88e2e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "spryker/agent-extension": "^1.0.0",
                 "spryker/comment-extension": "^1.0.0",
-                "spryker/currency": "^3.4.0",
+                "spryker/currency": "^3.4.0 || ^4.0.0",
                 "spryker/customer": "^6.0.0 || ^7.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/propel-orm": "^1.0.0",
-                "spryker/quote-extension": "^1.6.0",
+                "spryker/quote-extension": "^1.8.0",
                 "spryker/session": "^3.3.0 || ^4.14.0",
-                "spryker/store": "^1.11.0",
+                "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.25.0",
                 "spryker/util-encoding": "^2.0.0",
@@ -43034,7 +43746,9 @@
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/propel": "*",
+                "spryker/storage": "*",
                 "spryker/testify": "*"
             },
             "type": "library",
@@ -43055,9 +43769,9 @@
             ],
             "description": "Quote module",
             "support": {
-                "source": "https://github.com/spryker/quote/tree/2.17.0"
+                "source": "https://github.com/spryker/quote/tree/2.18.0"
             },
-            "time": "2023-01-24T16:01:46+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/quote-approval",
@@ -43219,20 +43933,20 @@
         },
         {
             "name": "spryker/quote-extension",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/quote-extension.git",
-                "reference": "971a47b862503c470655c9b55214a99f11b20fb7"
+                "reference": "eaec903bd29ae1fccac829f45137897f66aeefbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/quote-extension/zipball/971a47b862503c470655c9b55214a99f11b20fb7",
-                "reference": "971a47b862503c470655c9b55214a99f11b20fb7",
+                "url": "https://api.github.com/repos/spryker/quote-extension/zipball/eaec903bd29ae1fccac829f45137897f66aeefbc",
+                "reference": "eaec903bd29ae1fccac829f45137897f66aeefbc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -43254,9 +43968,9 @@
             ],
             "description": "QuoteExtension module",
             "support": {
-                "source": "https://github.com/spryker/quote-extension/tree/1.7.0"
+                "source": "https://github.com/spryker/quote-extension/tree/1.8.0"
             },
-            "time": "2021-03-30T13:18:02+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/quote-request",
@@ -43669,16 +44383,16 @@
         },
         {
             "name": "spryker/refund",
-            "version": "5.7.0",
+            "version": "5.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/refund.git",
-                "reference": "a05eb5e6315e6ca6886a7c77ee69879313a19a7d"
+                "reference": "108fcc579a30134a38f53ae19cbe1cea6ec3f87b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/refund/zipball/a05eb5e6315e6ca6886a7c77ee69879313a19a7d",
-                "reference": "a05eb5e6315e6ca6886a7c77ee69879313a19a7d",
+                "url": "https://api.github.com/repos/spryker/refund/zipball/108fcc579a30134a38f53ae19cbe1cea6ec3f87b",
+                "reference": "108fcc579a30134a38f53ae19cbe1cea6ec3f87b",
                 "shasum": ""
             },
             "require": {
@@ -43698,9 +44412,12 @@
                 "spryker/application": "*",
                 "spryker/code-sniffer": "*",
                 "spryker/config": "*",
+                "spryker/container": "*",
                 "spryker/oms": "*",
                 "spryker/propel": "^3.0.0",
                 "spryker/propel-orm": "^1.0.0",
+                "spryker/shipment": "*",
+                "spryker/store": "*",
                 "spryker/testify": "*",
                 "spryker/zed-navigation": "*"
             },
@@ -43721,9 +44438,9 @@
             ],
             "description": "Refund module",
             "support": {
-                "source": "https://github.com/spryker/refund/tree/5.7.0"
+                "source": "https://github.com/spryker/refund/tree/5.7.2"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-06-06T15:14:45+00:00"
         },
         {
             "name": "spryker/refund-extension",
@@ -43959,16 +44676,16 @@
         },
         {
             "name": "spryker/router",
-            "version": "1.15.0",
+            "version": "1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/router.git",
-                "reference": "dcb1b75acc08bc00ce1955708571ad2e72e72c8d"
+                "reference": "8eaf4245ce7e8e742726f596fa5431fe9fc936f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/router/zipball/dcb1b75acc08bc00ce1955708571ad2e72e72c8d",
-                "reference": "dcb1b75acc08bc00ce1955708571ad2e72e72c8d",
+                "url": "https://api.github.com/repos/spryker/router/zipball/8eaf4245ce7e8e742726f596fa5431fe9fc936f8",
+                "reference": "8eaf4245ce7e8e742726f596fa5431fe9fc936f8",
                 "shasum": ""
             },
             "require": {
@@ -44012,9 +44729,9 @@
             ],
             "description": "Router module",
             "support": {
-                "source": "https://github.com/spryker/router/tree/1.15.0"
+                "source": "https://github.com/spryker/router/tree/1.17.0"
             },
-            "time": "2023-01-24T16:01:46+00:00"
+            "time": "2023-10-10T10:57:01+00:00"
         },
         {
             "name": "spryker/router-extension",
@@ -44066,16 +44783,16 @@
         },
         {
             "name": "spryker/sales",
-            "version": "11.37.0",
+            "version": "11.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/sales.git",
-                "reference": "84021fbbe23a2251bda48206464fabaf21c57471"
+                "reference": "cb5f9d8a185ac8a3d163ac1cca5d63e39929fc99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/sales/zipball/84021fbbe23a2251bda48206464fabaf21c57471",
-                "reference": "84021fbbe23a2251bda48206464fabaf21c57471",
+                "url": "https://api.github.com/repos/spryker/sales/zipball/cb5f9d8a185ac8a3d163ac1cca5d63e39929fc99",
+                "reference": "cb5f9d8a185ac8a3d163ac1cca5d63e39929fc99",
                 "shasum": ""
             },
             "require": {
@@ -44083,11 +44800,11 @@
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/calculation": "^4.0.0",
                 "spryker/checkout-extension": "^1.2.0",
-                "spryker/country": "^3.1.0",
+                "spryker/country": "^3.1.0 || ^4.0.0",
                 "spryker/customer": "^6.5.0 || ^7.0.0",
                 "spryker/gui": "^3.39.0",
                 "spryker/kernel": "^3.33.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/money": "^2.0.0",
                 "spryker/oms": "^10.3.0 || ^11.0.0",
                 "spryker/propel": "^3.0.0",
@@ -44097,7 +44814,7 @@
                 "spryker/sequence-number": "^3.0.0",
                 "spryker/store": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/twig": "^3.16.0",
                 "spryker/user": "^3.0.0",
                 "spryker/util-date-time": "^1.0.0",
@@ -44110,6 +44827,7 @@
                 "spryker/checkout": "*",
                 "spryker/code-sniffer": "*",
                 "spryker/config": "*",
+                "spryker/container": "*",
                 "spryker/price": "*",
                 "spryker/product": "*",
                 "spryker/shipment": "*",
@@ -44140,9 +44858,9 @@
             ],
             "description": "Sales module",
             "support": {
-                "source": "https://github.com/spryker/sales/tree/11.37.0"
+                "source": "https://github.com/spryker/sales/tree/11.41.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-09-27T12:20:15+00:00"
         },
         {
             "name": "spryker/sales-configurable-bundle",
@@ -45887,16 +46605,16 @@
         },
         {
             "name": "spryker/search",
-            "version": "8.19.3",
+            "version": "8.21.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/search.git",
-                "reference": "6e4f84b004f63c42faa529eb2bf5caadf69db7e7"
+                "reference": "ed45907ec596f9222fc7fb07f4e728bc316833b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/search/zipball/6e4f84b004f63c42faa529eb2bf5caadf69db7e7",
-                "reference": "6e4f84b004f63c42faa529eb2bf5caadf69db7e7",
+                "url": "https://api.github.com/repos/spryker/search/zipball/ed45907ec596f9222fc7fb07f4e728bc316833b5",
+                "reference": "ed45907ec596f9222fc7fb07f4e728bc316833b5",
                 "shasum": ""
             },
             "require": {
@@ -45906,14 +46624,17 @@
                 "spryker/gui": "^3.0.0",
                 "spryker/guzzle": "^2.0.0",
                 "spryker/health-check-extension": "^1.0.0",
-                "spryker/kernel": "^3.52.0",
+                "spryker/kernel": "^3.72.0",
                 "spryker/laminas": "^1.0.0",
+                "spryker/locale": "^3.9.0 || ^4.0.0",
                 "spryker/log": "^3.0.0",
                 "spryker/money": "^2.0.0",
                 "spryker/product-page-search-extension": "^1.0.0",
-                "spryker/search-extension": "^1.1.0",
+                "spryker/search-extension": "^1.2.0",
                 "spryker/store": "^1.1.0",
+                "spryker/store-extension": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
+                "spryker/transfer": "^3.25.0",
                 "spryker/twig": "^3.0.0",
                 "spryker/util-encoding": "^2.0.0"
             },
@@ -45946,9 +46667,9 @@
             ],
             "description": "Search module",
             "support": {
-                "source": "https://github.com/spryker/search/tree/8.19.3"
+                "source": "https://github.com/spryker/search/tree/8.21.1"
             },
-            "time": "2023-02-20T10:18:53+00:00"
+            "time": "2023-09-11T11:36:57+00:00"
         },
         {
             "name": "spryker/search-elasticsearch",
@@ -46065,20 +46786,20 @@
         },
         {
             "name": "spryker/search-extension",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/search-extension.git",
-                "reference": "68847505a9097e3d46ce3f00b87cab71404349b9"
+                "reference": "149f7e2e993067718af9170eabc45fb58a255fda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/search-extension/zipball/68847505a9097e3d46ce3f00b87cab71404349b9",
-                "reference": "68847505a9097e3d46ce3f00b87cab71404349b9",
+                "url": "https://api.github.com/repos/spryker/search-extension/zipball/149f7e2e993067718af9170eabc45fb58a255fda",
+                "reference": "149f7e2e993067718af9170eabc45fb58a255fda",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
@@ -46105,9 +46826,9 @@
             ],
             "description": "SearchExtension module",
             "support": {
-                "source": "https://github.com/spryker/search-extension/tree/1.1.0"
+                "source": "https://github.com/spryker/search-extension/tree/1.3.0"
             },
-            "time": "2021-06-09T11:08:48+00:00"
+            "time": "2023-09-11T11:36:57+00:00"
         },
         {
             "name": "spryker/search-http",
@@ -46577,20 +47298,20 @@
         },
         {
             "name": "spryker/security-gui-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/security-gui-extension.git",
-                "reference": "fcda9ea737c127d69466f4a8524e9c7e3656ba9c"
+                "reference": "7df35059c98dd5dd17650a28b41b8197b24950a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/security-gui-extension/zipball/fcda9ea737c127d69466f4a8524e9c7e3656ba9c",
-                "reference": "fcda9ea737c127d69466f4a8524e9c7e3656ba9c",
+                "url": "https://api.github.com/repos/spryker/security-gui-extension/zipball/7df35059c98dd5dd17650a28b41b8197b24950a2",
+                "reference": "7df35059c98dd5dd17650a28b41b8197b24950a2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4"
+                "php": ">=8.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -46612,9 +47333,9 @@
             ],
             "description": "SecurityGuiExtension module",
             "support": {
-                "source": "https://github.com/spryker/security-gui-extension/tree/1.1.0"
+                "source": "https://github.com/spryker/security-gui-extension/tree/1.2.0"
             },
-            "time": "2021-12-10T09:14:37+00:00"
+            "time": "2023-02-08T12:23:08+00:00"
         },
         {
             "name": "spryker/security-oauth-user",
@@ -47527,25 +48248,25 @@
         },
         {
             "name": "spryker/shipment",
-            "version": "8.12.0",
+            "version": "8.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/shipment.git",
-                "reference": "2dd4a56a8aebcbfaca6fd27d0e7363835c51a772"
+                "reference": "8db63fbda1343fb0eb5af35d59e94061d9ce6d52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/shipment/zipball/2dd4a56a8aebcbfaca6fd27d0e7363835c51a772",
-                "reference": "2dd4a56a8aebcbfaca6fd27d0e7363835c51a772",
+                "url": "https://api.github.com/repos/spryker/shipment/zipball/8db63fbda1343fb0eb5af35d59e94061d9ce6d52",
+                "reference": "8db63fbda1343fb0eb5af35d59e94061d9ce6d52",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
-                "spryker/calculation": "^4.8.0",
+                "spryker/calculation": "^4.9.0",
                 "spryker/calculation-extension": "^1.0.0",
-                "spryker/country": "^3.0.0",
-                "spryker/currency": "^3.1.0",
+                "spryker/country": "^3.0.0 || ^4.0.0",
+                "spryker/currency": "^3.1.0 || ^4.0.0",
                 "spryker/customer": "^7.25.0",
                 "spryker/gui": "^3.17.0",
                 "spryker/kernel": "^3.30.0",
@@ -47553,18 +48274,20 @@
                 "spryker/price": "^5.5.0",
                 "spryker/propel-orm": "^1.0.0",
                 "spryker/sales": "^11.25.0",
+                "spryker/sales-extension": "^1.6.0",
                 "spryker/session": "^3.0.0 || ^4.0.0",
-                "spryker/shipment-extension": "^1.1.0",
+                "spryker/shipment-extension": "^1.2.0",
                 "spryker/store": "^1.4.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/tax": "^5.0.0",
-                "spryker/transfer": "^3.25.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/util-encoding": "^2.0.0",
                 "spryker/zed-request": "^3.0.0"
             },
             "require-dev": {
                 "spryker/checkout": "*",
                 "spryker/code-sniffer": "*",
+                "spryker/container": "*",
                 "spryker/product": "*",
                 "spryker/propel": "*",
                 "spryker/tax-product-connector": "*",
@@ -47591,9 +48314,9 @@
             ],
             "description": "Shipment module",
             "support": {
-                "source": "https://github.com/spryker/shipment/tree/8.12.0"
+                "source": "https://github.com/spryker/shipment/tree/8.18.0"
             },
-            "time": "2023-03-21T13:22:02+00:00"
+            "time": "2023-10-25T07:06:24+00:00"
         },
         {
             "name": "spryker/shipment-cart-connector",
@@ -47794,20 +48517,21 @@
         },
         {
             "name": "spryker/shipment-extension",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/shipment-extension.git",
-                "reference": "617c4a5fc41fc141f368e7133aab7e0cc8464b4a"
+                "reference": "60944ddd7eb0cb42da0e37ff3953590353434ba3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/shipment-extension/zipball/617c4a5fc41fc141f368e7133aab7e0cc8464b4a",
-                "reference": "617c4a5fc41fc141f368e7133aab7e0cc8464b4a",
+                "url": "https://api.github.com/repos/spryker/shipment-extension/zipball/60944ddd7eb0cb42da0e37ff3953590353434ba3",
+                "reference": "60944ddd7eb0cb42da0e37ff3953590353434ba3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2"
+                "php": ">=8.0",
+                "spryker/transfer": "^3.27.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*"
@@ -47829,9 +48553,9 @@
             ],
             "description": "ShipmentExtension module",
             "support": {
-                "source": "https://github.com/spryker/shipment-extension/tree/master"
+                "source": "https://github.com/spryker/shipment-extension/tree/1.2.0"
             },
-            "time": "2020-03-11T14:56:31+00:00"
+            "time": "2023-08-01T09:25:56+00:00"
         },
         {
             "name": "spryker/shipment-gui",
@@ -48745,16 +49469,16 @@
         },
         {
             "name": "spryker/stock",
-            "version": "8.7.0",
+            "version": "8.8.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/stock.git",
-                "reference": "e37f883e821a358ce9ecb3c1c627845d655f9746"
+                "reference": "5261ab0f27009e6e3bae8d9edc44b83f52353138"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/stock/zipball/e37f883e821a358ce9ecb3c1c627845d655f9746",
-                "reference": "e37f883e821a358ce9ecb3c1c627845d655f9746",
+                "url": "https://api.github.com/repos/spryker/stock/zipball/5261ab0f27009e6e3bae8d9edc44b83f52353138",
+                "reference": "5261ab0f27009e6e3bae8d9edc44b83f52353138",
                 "shasum": ""
             },
             "require": {
@@ -48793,9 +49517,9 @@
             ],
             "description": "Stock module",
             "support": {
-                "source": "https://github.com/spryker/stock/tree/8.7.0"
+                "source": "https://github.com/spryker/stock/tree/8.8.3"
             },
-            "time": "2023-03-16T13:08:01+00:00"
+            "time": "2023-07-25T12:51:44+00:00"
         },
         {
             "name": "spryker/stock-address",
@@ -49031,16 +49755,16 @@
         },
         {
             "name": "spryker/storage",
-            "version": "3.19.2",
+            "version": "3.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/storage.git",
-                "reference": "6bb5c19743ee633155c0eb85bb8d40d4893b5e5d"
+                "reference": "826ba5c9c4b26b2d3dbf2c9791975ee3857f04f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/storage/zipball/6bb5c19743ee633155c0eb85bb8d40d4893b5e5d",
-                "reference": "6bb5c19743ee633155c0eb85bb8d40d4893b5e5d",
+                "url": "https://api.github.com/repos/spryker/storage/zipball/826ba5c9c4b26b2d3dbf2c9791975ee3857f04f2",
+                "reference": "826ba5c9c4b26b2d3dbf2c9791975ee3857f04f2",
                 "shasum": ""
             },
             "require": {
@@ -49050,10 +49774,10 @@
                 "spryker/gui": "^3.0.0",
                 "spryker/health-check-extension": "^1.0.0",
                 "spryker/kernel": "^3.41.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/redis": "^2.2.0",
                 "spryker/storage-extension": "^1.1.0",
-                "spryker/store": "^1.4.0",
+                "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.5.0",
                 "spryker/util-sanitize": "^2.0.0",
                 "spryker/util-text": "^1.1.0"
@@ -49081,7 +49805,8 @@
             "autoload": {
                 "psr-4": {
                     "Spryker\\": "src/Spryker/",
-                    "SprykerTest\\Client\\Storage\\Helper\\": "tests/SprykerTest/Client/Storage/_support/Helper/"
+                    "SprykerTest\\Client\\Storage\\Helper\\": "tests/SprykerTest/Client/Storage/_support/Helper/",
+                    "SprykerTest\\Shared\\Storage\\Helper\\": "tests/SprykerTest/Shared/Storage/_support/Helper/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -49090,9 +49815,9 @@
             ],
             "description": "Storage module",
             "support": {
-                "source": "https://github.com/spryker/storage/tree/3.19.2"
+                "source": "https://github.com/spryker/storage/tree/3.21.0"
             },
-            "time": "2022-12-01T11:40:47+00:00"
+            "time": "2023-07-24T13:36:15+00:00"
         },
         {
             "name": "spryker/storage-database",
@@ -49327,16 +50052,16 @@
         },
         {
             "name": "spryker/store",
-            "version": "1.18.1",
+            "version": "1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/store.git",
-                "reference": "370f6b23a6ea54d3198408b9d22075f36c6ffc4f"
+                "reference": "d0d3009c346c1f785ee455ee98b1e47dd8e1044a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/store/zipball/370f6b23a6ea54d3198408b9d22075f36c6ffc4f",
-                "reference": "370f6b23a6ea54d3198408b9d22075f36c6ffc4f",
+                "url": "https://api.github.com/repos/spryker/store/zipball/d0d3009c346c1f785ee455ee98b1e47dd8e1044a",
+                "reference": "d0d3009c346c1f785ee455ee98b1e47dd8e1044a",
                 "shasum": ""
             },
             "require": {
@@ -49349,12 +50074,16 @@
                 "spryker/oauth-client-extension": "^1.0.0",
                 "spryker/propel-orm": "^1.0.0",
                 "spryker/quote-extension": "^1.4.0",
+                "spryker/store-extension": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
-                "spryker/transfer": "^3.25.0"
+                "spryker/transfer": "^3.25.0",
+                "spryker/zed-request": "^3.3.0",
+                "spryker/zed-request-extension": "^1.1.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
                 "spryker/container": "*",
+                "spryker/locale": "*",
                 "spryker/propel": "*",
                 "spryker/quote": "*",
                 "spryker/testify": "*"
@@ -49382,9 +50111,51 @@
             ],
             "description": "Store module",
             "support": {
-                "source": "https://github.com/spryker/store/tree/1.18.1"
+                "source": "https://github.com/spryker/store/tree/1.23.1"
             },
-            "time": "2023-03-14T08:26:09+00:00"
+            "time": "2023-08-31T11:27:42+00:00"
+        },
+        {
+            "name": "spryker/store-extension",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/store-extension.git",
+                "reference": "b95dbb1e7a72d455f961891a27645cf1b3ea4672"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/store-extension/zipball/b95dbb1e7a72d455f961891a27645cf1b3ea4672",
+                "reference": "b95dbb1e7a72d455f961891a27645cf1b3ea4672",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/transfer": "^3.0.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "StoreExtension module",
+            "support": {
+                "source": "https://github.com/spryker/store-extension/tree/1.0.0"
+            },
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/store-gui",
@@ -49483,16 +50254,16 @@
         },
         {
             "name": "spryker/symfony",
-            "version": "3.11.1",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/symfony.git",
-                "reference": "637504de61601f39ffac01bd47b6200e8fe30822"
+                "reference": "63730730f5f3a9fdaf8fcb46c3dc9272fff3226c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/symfony/zipball/637504de61601f39ffac01bd47b6200e8fe30822",
-                "reference": "637504de61601f39ffac01bd47b6200e8fe30822",
+                "url": "https://api.github.com/repos/spryker/symfony/zipball/63730730f5f3a9fdaf8fcb46c3dc9272fff3226c",
+                "reference": "63730730f5f3a9fdaf8fcb46c3dc9272fff3226c",
                 "shasum": ""
             },
             "require": {
@@ -49508,18 +50279,18 @@
                 "symfony/form": "^5.2.0 || ^6.0.0",
                 "symfony/http-client": "^5.0.9 || ^6.0.0",
                 "symfony/http-foundation": "^5.2.0 || ^6.0.0",
-                "symfony/http-kernel": "^5.2.0 || ^6.0.0",
+                "symfony/http-kernel": "^5.2.1 || ^6.0.0",
                 "symfony/intl": "^5.0.9 || ^6.0.0",
-                "symfony/messenger": "^5.0.0 || ^6.0.0",
+                "symfony/messenger": "^5.3.0 || ^6.0.0",
                 "symfony/mime": "^5.0.9 || ^6.0.0",
                 "symfony/options-resolver": "^5.0.9 || ^6.0.0",
                 "symfony/process": "^5.4.0 || ^6.0.0",
                 "symfony/property-access": "^5.4.0 || ^6.0.0",
                 "symfony/routing": "^5.1.0 || ^6.0.0",
-                "symfony/security-core": "^5.2.8",
+                "symfony/security-core": "^5.4.21",
                 "symfony/security-csrf": "^5.3.0 || ^6.0.0",
-                "symfony/security-guard": "^5.2.8",
-                "symfony/security-http": "^5.2.8",
+                "symfony/security-guard": "^5.4.21",
+                "symfony/security-http": "^5.4.21",
                 "symfony/serializer": "^5.0.9 || ^6.0.0",
                 "symfony/stopwatch": "^5.0.9 || ^6.0.0",
                 "symfony/translation": "^5.0.9 || ^6.0.0",
@@ -49550,9 +50321,9 @@
             ],
             "description": "Symfony module",
             "support": {
-                "source": "https://github.com/spryker/symfony/tree/3.11.1"
+                "source": "https://github.com/spryker/symfony/tree/3.12.0"
             },
-            "time": "2023-01-27T13:52:43+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/symfony-mailer",
@@ -49607,16 +50378,16 @@
         },
         {
             "name": "spryker/synchronization",
-            "version": "1.15.0",
+            "version": "1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/synchronization.git",
-                "reference": "443dc17dbf675f02a7ab4b1a2c6269917ad6bdd1"
+                "reference": "1912e214c56e14b594d63e377455102ef014379c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/synchronization/zipball/443dc17dbf675f02a7ab4b1a2c6269917ad6bdd1",
-                "reference": "443dc17dbf675f02a7ab4b1a2c6269917ad6bdd1",
+                "url": "https://api.github.com/repos/spryker/synchronization/zipball/1912e214c56e14b594d63e377455102ef014379c",
+                "reference": "1912e214c56e14b594d63e377455102ef014379c",
                 "shasum": ""
             },
             "require": {
@@ -49627,6 +50398,7 @@
                 "spryker/queue": "^1.0.0",
                 "spryker/search": "^8.3.0",
                 "spryker/storage": "^3.4.1",
+                "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.1.0",
                 "spryker/synchronization-extension": "^1.3.0",
                 "spryker/transfer": "^3.25.0",
@@ -49682,26 +50454,26 @@
             ],
             "description": "Synchronization module",
             "support": {
-                "source": "https://github.com/spryker/synchronization/tree/1.15.0"
+                "source": "https://github.com/spryker/synchronization/tree/1.16.0"
             },
-            "time": "2022-12-14T14:25:39+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/synchronization-behavior",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/synchronization-behavior.git",
-                "reference": "f9f9dd276794409fc80d031f89ee905b3067d0df"
+                "reference": "648d7e3ce8374bf6b6f82fbeade432514b841eaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/synchronization-behavior/zipball/f9f9dd276794409fc80d031f89ee905b3067d0df",
-                "reference": "f9f9dd276794409fc80d031f89ee905b3067d0df",
+                "url": "https://api.github.com/repos/spryker/synchronization-behavior/zipball/648d7e3ce8374bf6b6f82fbeade432514b841eaa",
+                "reference": "648d7e3ce8374bf6b6f82fbeade432514b841eaa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/laminas": "^1.0.0",
                 "spryker/propel-orm": "^1.16.0",
@@ -49737,7 +50509,7 @@
             "support": {
                 "source": "https://github.com/spryker/synchronization-behavior"
             },
-            "time": "2022-07-01T12:54:12+00:00"
+            "time": "2023-03-31T19:36:17+00:00"
         },
         {
             "name": "spryker/synchronization-extension",
@@ -49786,27 +50558,28 @@
         },
         {
             "name": "spryker/tax",
-            "version": "5.13.0",
+            "version": "5.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/tax.git",
-                "reference": "73e41edd169e354b16ed31c3bfd5336b85353da5"
+                "reference": "391a9fb49a66a2c284ce0e00f914f45c6539e83f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/tax/zipball/73e41edd169e354b16ed31c3bfd5336b85353da5",
-                "reference": "73e41edd169e354b16ed31c3bfd5336b85353da5",
+                "url": "https://api.github.com/repos/spryker/tax/zipball/391a9fb49a66a2c284ce0e00f914f45c6539e83f",
+                "reference": "391a9fb49a66a2c284ce0e00f914f45c6539e83f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/calculation": "^4.0.0",
-                "spryker/country": "^3.0.0",
+                "spryker/country": "^3.0.0 || ^4.0.0",
                 "spryker/gui": "^3.45.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/propel-orm": "^1.0.0",
+                "spryker/store": "^1.19.0",
                 "spryker/symfony": "^3.0.0",
                 "spryker/transfer": "^3.27.0",
                 "spryker/twig": "^3.16.0",
@@ -49843,9 +50616,50 @@
             ],
             "description": "Tax module",
             "support": {
-                "source": "https://github.com/spryker/tax/tree/5.13.0"
+                "source": "https://github.com/spryker/tax/tree/5.14.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
+        },
+        {
+            "name": "spryker/tax-app-extension",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/tax-app-extension.git",
+                "reference": "30ccc74646fe91083356c76e7f86b772816fe4ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/tax-app-extension/zipball/30ccc74646fe91083356c76e7f86b772816fe4ce",
+                "reference": "30ccc74646fe91083356c76e7f86b772816fe4ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "TaxAppExtension module",
+            "support": {
+                "source": "https://github.com/spryker/tax-app-extension/tree/1.0.0"
+            },
+            "time": "2023-09-18T09:59:00+00:00"
         },
         {
             "name": "spryker/tax-product-connector",
@@ -50062,22 +50876,22 @@
         },
         {
             "name": "spryker/touch",
-            "version": "4.5.0",
+            "version": "4.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/touch.git",
-                "reference": "107696e619cf829030e866097d3f430f7f61749c"
+                "reference": "83fdd4458fbd9cbfe66053d51f535b5446602fdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/touch/zipball/107696e619cf829030e866097d3f430f7f61749c",
-                "reference": "107696e619cf829030e866097d3f430f7f61749c",
+                "url": "https://api.github.com/repos/spryker/touch/zipball/83fdd4458fbd9cbfe66053d51f535b5446602fdf",
+                "reference": "83fdd4458fbd9cbfe66053d51f535b5446602fdf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
+                "php": ">=8.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/propel-orm": "^1.0.0",
                 "spryker/store": "^1.0.0",
                 "spryker/symfony": "^3.0.0",
@@ -50106,9 +50920,9 @@
             ],
             "description": "Touch module",
             "support": {
-                "source": "https://github.com/spryker/touch/tree/4.5.0"
+                "source": "https://github.com/spryker/touch/tree/4.6.0"
             },
-            "time": "2021-05-13T14:04:54+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/transfer",
@@ -50163,16 +50977,16 @@
         },
         {
             "name": "spryker/translator",
-            "version": "1.10.0",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/translator.git",
-                "reference": "1ab03edbe255a81ae019e100378af667ecc10f41"
+                "reference": "0ab70852c213081b053bdf42914cf1eaebaa13ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/translator/zipball/1ab03edbe255a81ae019e100378af667ecc10f41",
-                "reference": "1ab03edbe255a81ae019e100378af667ecc10f41",
+                "url": "https://api.github.com/repos/spryker/translator/zipball/0ab70852c213081b053bdf42914cf1eaebaa13ac",
+                "reference": "0ab70852c213081b053bdf42914cf1eaebaa13ac",
                 "shasum": ""
             },
             "require": {
@@ -50180,7 +50994,7 @@
                 "spryker/application-extension": "^1.0.0",
                 "spryker/glossary-storage": "^1.0.0",
                 "spryker/kernel": "^3.52.0",
-                "spryker/locale": "^3.3.0",
+                "spryker/locale": "^3.3.0 || ^4.0.0",
                 "spryker/messenger-extension": "^1.0.0",
                 "spryker/symfony": "^3.5.0",
                 "spryker/translator-extension": "^1.0.0",
@@ -50216,9 +51030,9 @@
             ],
             "description": "Translator module",
             "support": {
-                "source": "https://github.com/spryker/translator/tree/1.10.0"
+                "source": "https://github.com/spryker/translator/tree/1.11.0"
             },
-            "time": "2023-01-24T16:01:46+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/translator-extension",
@@ -50267,16 +51081,16 @@
         },
         {
             "name": "spryker/twig",
-            "version": "3.18.0",
+            "version": "3.18.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/twig.git",
-                "reference": "23ac0429e51f94e1f6375423b2ca8ed3943f069d"
+                "reference": "7a44c1b4614fb2ed9e3dc9e30fab4d733ad797ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/twig/zipball/23ac0429e51f94e1f6375423b2ca8ed3943f069d",
-                "reference": "23ac0429e51f94e1f6375423b2ca8ed3943f069d",
+                "url": "https://api.github.com/repos/spryker/twig/zipball/7a44c1b4614fb2ed9e3dc9e30fab4d733ad797ce",
+                "reference": "7a44c1b4614fb2ed9e3dc9e30fab4d733ad797ce",
                 "shasum": ""
             },
             "require": {
@@ -50321,9 +51135,9 @@
             ],
             "description": "Twig module",
             "support": {
-                "source": "https://github.com/spryker/twig/tree/3.18.0"
+                "source": "https://github.com/spryker/twig/tree/3.18.2"
             },
-            "time": "2022-11-24T12:58:29+00:00"
+            "time": "2023-07-27T15:38:05+00:00"
         },
         {
             "name": "spryker/twig-extension",
@@ -50423,16 +51237,16 @@
         },
         {
             "name": "spryker/url",
-            "version": "3.11.0",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/url.git",
-                "reference": "e107ac791081d577dcb116b501b13743636da3c4"
+                "reference": "c2b6dfb9739f3a52acc46dad05e99706594c8154"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/url/zipball/e107ac791081d577dcb116b501b13743636da3c4",
-                "reference": "e107ac791081d577dcb116b501b13743636da3c4",
+                "url": "https://api.github.com/repos/spryker/url/zipball/c2b6dfb9739f3a52acc46dad05e99706594c8154",
+                "reference": "c2b6dfb9739f3a52acc46dad05e99706594c8154",
                 "shasum": ""
             },
             "require": {
@@ -50440,7 +51254,7 @@
                 "spryker/acl-merchant-portal-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
                 "spryker/key-builder": "^1.0.0",
-                "spryker/locale": "^3.8.0",
+                "spryker/locale": "^3.8.0 || ^4.0.0",
                 "spryker/propel-orm": "^1.16.0",
                 "spryker/storage": "^3.0.0",
                 "spryker/symfony": "^3.0.0",
@@ -50477,9 +51291,9 @@
             ],
             "description": "Url module",
             "support": {
-                "source": "https://github.com/spryker/url/tree/3.11.0"
+                "source": "https://github.com/spryker/url/tree/3.12.0"
             },
-            "time": "2023-03-10T14:11:16+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/url-storage",
@@ -50633,16 +51447,16 @@
         },
         {
             "name": "spryker/user",
-            "version": "3.17.0",
+            "version": "3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/user.git",
-                "reference": "7f73c285def01ceaae191118fbfd2e5cbcef41bc"
+                "reference": "f088b1f83625ba4fe6610d28e220ac2e7de2f788"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/user/zipball/7f73c285def01ceaae191118fbfd2e5cbcef41bc",
-                "reference": "7f73c285def01ceaae191118fbfd2e5cbcef41bc",
+                "url": "https://api.github.com/repos/spryker/user/zipball/f088b1f83625ba4fe6610d28e220ac2e7de2f788",
+                "reference": "f088b1f83625ba4fe6610d28e220ac2e7de2f788",
                 "shasum": ""
             },
             "require": {
@@ -50670,6 +51484,7 @@
                 "spryker/router": "*",
                 "spryker/security": "*",
                 "spryker/silex": "*",
+                "spryker/store": "*",
                 "spryker/testify": "*",
                 "spryker/twig": "*",
                 "spryker/validator": "*",
@@ -50699,9 +51514,9 @@
             ],
             "description": "User module",
             "support": {
-                "source": "https://github.com/spryker/user/tree/3.17.0"
+                "source": "https://github.com/spryker/user/tree/3.18.0"
             },
-            "time": "2023-03-03T10:26:17+00:00"
+            "time": "2023-04-17T15:49:27+00:00"
         },
         {
             "name": "spryker/user-extension",
@@ -50753,30 +51568,34 @@
         },
         {
             "name": "spryker/user-locale",
-            "version": "1.1.1",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/user-locale.git",
-                "reference": "9c623d2b1b48789daa6b0d53f38178337e6d34ae"
+                "reference": "db0e184a49a131a49a9da3f713211808f14c0bd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/user-locale/zipball/9c623d2b1b48789daa6b0d53f38178337e6d34ae",
-                "reference": "9c623d2b1b48789daa6b0d53f38178337e6d34ae",
+                "url": "https://api.github.com/repos/spryker/user-locale/zipball/db0e184a49a131a49a9da3f713211808f14c0bd0",
+                "reference": "db0e184a49a131a49a9da3f713211808f14c0bd0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
+                "php": ">=8.0",
                 "spryker/application-extension": "^1.0.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.3.0 || ^4.0.0",
                 "spryker/locale-extension": "^1.0.0",
+                "spryker/store": "^1.19.0",
+                "spryker/transfer": "^3.27.0",
                 "spryker/user": "^3.7.0",
-                "spryker/user-extension": "^1.1.0"
+                "spryker/user-extension": "^1.2.0"
             },
             "require-dev": {
                 "spryker/code-sniffer": "*",
-                "spryker/container": "*"
+                "spryker/container": "*",
+                "spryker/propel": "*",
+                "spryker/testify": "*"
             },
             "suggest": {
                 "spryker/container": "If you want to use Application plugins. Minimum required version: 1.0.0",
@@ -50799,9 +51618,9 @@
             ],
             "description": "UserLocale module",
             "support": {
-                "source": "https://github.com/spryker/user-locale/tree/master"
+                "source": "https://github.com/spryker/user-locale/tree/1.3.0"
             },
-            "time": "2020-05-29T13:08:37+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
         },
         {
             "name": "spryker/user-locale-gui",
@@ -50850,23 +51669,119 @@
             "time": "2020-05-29T13:08:37+00:00"
         },
         {
-            "name": "spryker/user-password-reset",
-            "version": "1.1.0",
+            "name": "spryker/user-merchant-portal-gui",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/spryker/user-password-reset.git",
-                "reference": "9a004a50471a643fd1c438625f397ea6764d130e"
+                "url": "https://github.com/spryker/user-merchant-portal-gui.git",
+                "reference": "d7b02a89a7c894146ff274c361aebd9aaba162a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/user-password-reset/zipball/9a004a50471a643fd1c438625f397ea6764d130e",
-                "reference": "9a004a50471a643fd1c438625f397ea6764d130e",
+                "url": "https://api.github.com/repos/spryker/user-merchant-portal-gui/zipball/d7b02a89a7c894146ff274c361aebd9aaba162a9",
+                "reference": "d7b02a89a7c894146ff274c361aebd9aaba162a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4",
+                "php": ">=8.0",
+                "spryker/acl-merchant-portal-extension": "^1.0.0",
+                "spryker/gui": "^3.48.0",
                 "spryker/kernel": "^3.30.0",
-                "spryker/user": "^3.9.0",
+                "spryker/locale": "^3.2.0",
+                "spryker/merchant-user": "^1.3.0",
+                "spryker/symfony": "^3.0.0",
+                "spryker/transfer": "^3.27.0",
+                "spryker/translator": "^1.1.0",
+                "spryker/user-locale": "^1.0.0",
+                "spryker/user-merchant-portal-gui-extension": "^1.0.0",
+                "spryker/zed-ui": "^2.0.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/testify": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "UserMerchantPortalGui module",
+            "support": {
+                "source": "https://github.com/spryker/user-merchant-portal-gui/tree/2.3.0"
+            },
+            "time": "2023-03-13T13:20:27+00:00"
+        },
+        {
+            "name": "spryker/user-merchant-portal-gui-extension",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/user-merchant-portal-gui-extension.git",
+                "reference": "c3e838287c83663622ea23f3c6754956e5300a35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/user-merchant-portal-gui-extension/zipball/c3e838287c83663622ea23f3c6754956e5300a35",
+                "reference": "c3e838287c83663622ea23f3c6754956e5300a35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "UserMerchantPortalGuiExtension module",
+            "support": {
+                "source": "https://github.com/spryker/user-merchant-portal-gui-extension/tree/1.0.0"
+            },
+            "time": "2021-07-07T15:14:17+00:00"
+        },
+        {
+            "name": "spryker/user-password-reset",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/user-password-reset.git",
+                "reference": "c2cbea430658f1d4a0b4f110018e43d4cdcac450"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/user-password-reset/zipball/c2cbea430658f1d4a0b4f110018e43d4cdcac450",
+                "reference": "c2cbea430658f1d4a0b4f110018e43d4cdcac450",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/acl-merchant-portal-extension": "^1.0.0",
+                "spryker/kernel": "^3.30.0",
+                "spryker/transfer": "^3.27.0",
+                "spryker/user": "^3.17.0",
                 "spryker/user-password-reset-extension": "^1.0.0",
                 "spryker/util-text": "^1.2.2"
             },
@@ -50892,9 +51807,9 @@
             ],
             "description": "UserPasswordReset module",
             "support": {
-                "source": "https://github.com/spryker/user-password-reset/tree/1.1.0"
+                "source": "https://github.com/spryker/user-password-reset/tree/1.4.0"
             },
-            "time": "2022-05-26T12:51:48+00:00"
+            "time": "2023-03-10T14:11:16+00:00"
         },
         {
             "name": "spryker/user-password-reset-extension",
@@ -51079,16 +51994,16 @@
         },
         {
             "name": "spryker/util-date-time",
-            "version": "1.3.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/util-date-time.git",
-                "reference": "a52bc7cc78253ce9bc04d29a73aacaf8f9634b22"
+                "reference": "01a1c0ca748c9d04faaa2dc404a2232132157962"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/util-date-time/zipball/a52bc7cc78253ce9bc04d29a73aacaf8f9634b22",
-                "reference": "a52bc7cc78253ce9bc04d29a73aacaf8f9634b22",
+                "url": "https://api.github.com/repos/spryker/util-date-time/zipball/01a1c0ca748c9d04faaa2dc404a2232132157962",
+                "reference": "01a1c0ca748c9d04faaa2dc404a2232132157962",
                 "shasum": ""
             },
             "require": {
@@ -51124,9 +52039,9 @@
             ],
             "description": "UtilDateTime module",
             "support": {
-                "source": "https://github.com/spryker/util-date-time/tree/1.3.0"
+                "source": "https://github.com/spryker/util-date-time/tree/1.4.1"
             },
-            "time": "2023-03-13T09:36:48+00:00"
+            "time": "2023-07-27T15:38:05+00:00"
         },
         {
             "name": "spryker/util-encoding",
@@ -51939,6 +52854,40 @@
             "time": "2019-10-09T04:52:31+00:00"
         },
         {
+            "name": "spryker/willdurand-negotiation",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/willdurand-negotiation.git",
+                "reference": "d94edafb762e7d1b65c140c8df62aadece12eb8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/willdurand-negotiation/zipball/d94edafb762e7d1b65c140c8df62aadece12eb8b",
+                "reference": "d94edafb762e7d1b65c140c8df62aadece12eb8b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "willdurand/negotiation": "^2.3.0 || ^3.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "WilldurandNegotiation module",
+            "support": {
+                "source": "https://github.com/spryker/willdurand-negotiation/tree/1.0.0"
+            },
+            "time": "2023-10-17T16:01:45+00:00"
+        },
+        {
             "name": "spryker/wishlist-extension",
             "version": "1.3.0",
             "source": {
@@ -52126,35 +53075,36 @@
         },
         {
             "name": "spryker/zed-request",
-            "version": "3.18.1",
+            "version": "3.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/zed-request.git",
-                "reference": "919d123180784a9607e155bc7f1b0ad03f3de841"
+                "reference": "b06b5e843f8b3406436b0567dc6dd6581725fa1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/zed-request/zipball/919d123180784a9607e155bc7f1b0ad03f3de841",
-                "reference": "919d123180784a9607e155bc7f1b0ad03f3de841",
+                "url": "https://api.github.com/repos/spryker/zed-request/zipball/b06b5e843f8b3406436b0567dc6dd6581725fa1a",
+                "reference": "b06b5e843f8b3406436b0567dc6dd6581725fa1a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.0",
                 "psr/http-message": "^1.0.0",
+                "spryker/application-extension": "^1.1.0",
                 "spryker/config": "^3.0.0",
                 "spryker/error-handler": "^2.1.0",
                 "spryker/event-dispatcher-extension": "^1.0.0",
                 "spryker/guzzle": "^2.1.0",
                 "spryker/health-check-extension": "^1.0.0",
                 "spryker/kernel": "^3.52.0",
-                "spryker/locale": "^3.0.0",
+                "spryker/locale": "^3.0.0 || ^4.0.0",
                 "spryker/messenger": "^3.0.0",
                 "spryker/symfony": "^3.5.0",
                 "spryker/util-encoding": "^2.0.0",
                 "spryker/util-network": "^1.1.0",
                 "spryker/util-text": "^1.1.0",
                 "spryker/web-profiler-extension": "^1.0.0",
-                "spryker/zed-request-extension": "^1.0.0"
+                "spryker/zed-request-extension": "^1.1.0"
             },
             "require-dev": {
                 "spryker/application": "^3.2.0",
@@ -52190,29 +53140,33 @@
             ],
             "description": "ZedRequest module",
             "support": {
-                "source": "https://github.com/spryker/zed-request/tree/3.18.1"
+                "source": "https://github.com/spryker/zed-request/tree/3.20.0"
             },
-            "time": "2022-11-11T07:06:41+00:00"
+            "time": "2023-10-19T09:26:16+00:00"
         },
         {
             "name": "spryker/zed-request-extension",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spryker/zed-request-extension.git",
-                "reference": "4607cea5e438b72b452aae5f405859e2a6f4be43"
+                "reference": "318e6673af03bab7f52fdddc74af9cbab0638eb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spryker/zed-request-extension/zipball/4607cea5e438b72b452aae5f405859e2a6f4be43",
-                "reference": "4607cea5e438b72b452aae5f405859e2a6f4be43",
+                "url": "https://api.github.com/repos/spryker/zed-request-extension/zipball/318e6673af03bab7f52fdddc74af9cbab0638eb8",
+                "reference": "318e6673af03bab7f52fdddc74af9cbab0638eb8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.0"
             },
             "require-dev": {
-                "spryker/code-sniffer": "*"
+                "spryker/code-sniffer": "*",
+                "spryker/kernel": "*"
+            },
+            "suggest": {
+                "spryker/kernel": "If you want to use kernel functionality with certain plugins"
             },
             "type": "library",
             "extra": {
@@ -52231,9 +53185,64 @@
             ],
             "description": "ZedRequestExtension module",
             "support": {
-                "source": "https://github.com/spryker/zed-request-extension/tree/1.0.0"
+                "source": "https://github.com/spryker/zed-request-extension/tree/1.1.0"
             },
-            "time": "2020-11-11T13:55:08+00:00"
+            "time": "2023-03-31T19:36:11+00:00"
+        },
+        {
+            "name": "spryker/zed-ui",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/zed-ui.git",
+                "reference": "68286df3a6d3006369403a369ca050b8dd28cdf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/zed-ui/zipball/68286df3a6d3006369403a369ca050b8dd28cdf8",
+                "reference": "68286df3a6d3006369403a369ca050b8dd28cdf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0",
+                "spryker/application-extension": "^1.0.0",
+                "spryker/kernel": "^3.33.0",
+                "spryker/symfony": "^3.0.0",
+                "spryker/transfer": "^3.27.0",
+                "spryker/translator": "^1.1.0",
+                "spryker/twig": "^3.13.0",
+                "spryker/twig-extension": "^1.0.0",
+                "spryker/util-encoding": "^2.1.0"
+            },
+            "require-dev": {
+                "spryker/code-sniffer": "*",
+                "spryker/container": "*"
+            },
+            "suggest": {
+                "spryker/container": "If you want to use Twig plugins",
+                "spryker/ui-components": "If you want to use Spryker web components in HTML.",
+                "spryker/zed-navigation": "If you want to use the navigation."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "src/Spryker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "proprietary"
+            ],
+            "description": "ZedUi module",
+            "support": {
+                "source": "https://github.com/spryker/zed-ui/tree/2.2.0"
+            },
+            "time": "2023-09-12T13:38:42+00:00"
         },
         {
             "name": "stella-maris/clock",
@@ -52572,16 +53581,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.21",
+            "version": "v5.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c77433ddc6cdc689caf48065d9ea22ca0853fbd9"
+                "reference": "c70df1ffaf23a8d340bded3cfab1b86752ad6ed7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c77433ddc6cdc689caf48065d9ea22ca0853fbd9",
-                "reference": "c77433ddc6cdc689caf48065d9ea22ca0853fbd9",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c70df1ffaf23a8d340bded3cfab1b86752ad6ed7",
+                "reference": "c70df1ffaf23a8d340bded3cfab1b86752ad6ed7",
                 "shasum": ""
             },
             "require": {
@@ -52646,12 +53655,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.21"
+                "source": "https://github.com/symfony/console/tree/v5.4.32"
             },
             "funding": [
                 {
@@ -52667,7 +53676,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-25T16:59:41+00:00"
+            "time": "2023-11-18T18:23:04+00:00"
         },
         {
             "name": "symfony/debug",
@@ -53103,16 +54112,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.4.21",
+            "version": "v5.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19"
+                "reference": "ff4bce3c33451e7ec778070e45bd23f74214cd5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/078e9a5e1871fcfe6a5ce421b539344c21afef19",
-                "reference": "078e9a5e1871fcfe6a5ce421b539344c21afef19",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ff4bce3c33451e7ec778070e45bd23f74214cd5d",
+                "reference": "ff4bce3c33451e7ec778070e45bd23f74214cd5d",
                 "shasum": ""
             },
             "require": {
@@ -53146,7 +54155,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.21"
+                "source": "https://github.com/symfony/finder/tree/v5.4.27"
             },
             "funding": [
                 {
@@ -53162,7 +54171,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-16T09:33:00+00:00"
+            "time": "2023-07-31T08:02:31+00:00"
         },
         {
             "name": "symfony/form",
@@ -53430,30 +54439,31 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.0.20",
+            "version": "v5.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "e16b2676a4b3b1fa12378a20b29c364feda2a8d6"
+                "reference": "cbcd80a4c36f59772d62860fdb0cb6a38da63fd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e16b2676a4b3b1fa12378a20b29c364feda2a8d6",
-                "reference": "e16b2676a4b3b1fa12378a20b29c364feda2a8d6",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/cbcd80a4c36f59772d62860fdb0cb6a38da63fd2",
+                "reference": "cbcd80a4c36f59772d62860fdb0cb6a38da63fd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=7.2.5",
                 "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/polyfill-mbstring": "~1.1"
+                "symfony/polyfill-mbstring": "~1.1",
+                "symfony/polyfill-php80": "^1.16"
             },
             "require-dev": {
                 "predis/predis": "~1.0",
-                "symfony/cache": "^5.4|^6.0",
+                "symfony/cache": "^4.4|^5.0|^6.0",
                 "symfony/dependency-injection": "^5.4|^6.0",
-                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/expression-language": "^4.4|^5.0|^6.0",
                 "symfony/http-kernel": "^5.4.12|^6.0.12|^6.1.4",
-                "symfony/mime": "^5.4|^6.0",
+                "symfony/mime": "^4.4|^5.0|^6.0",
                 "symfony/rate-limiter": "^5.2|^6.0"
             },
             "suggest": {
@@ -53485,7 +54495,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.0.20"
+                "source": "https://github.com/symfony/http-foundation/tree/v5.4.32"
             },
             "funding": [
                 {
@@ -53501,20 +54511,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-30T15:41:07+00:00"
+            "time": "2023-11-20T15:40:25+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v5.4.20",
+            "version": "v5.4.32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "aaeec341582d3c160cc9ecfa8b2419ba6c69954e"
+                "reference": "442472752e3adc9810a7e425824497dc22f75acf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/aaeec341582d3c160cc9ecfa8b2419ba6c69954e",
-                "reference": "aaeec341582d3c160cc9ecfa8b2419ba6c69954e",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/442472752e3adc9810a7e425824497dc22f75acf",
+                "reference": "442472752e3adc9810a7e425824497dc22f75acf",
                 "shasum": ""
             },
             "require": {
@@ -53523,7 +54533,7 @@
                 "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/error-handler": "^4.4|^5.0|^6.0",
                 "symfony/event-dispatcher": "^5.0|^6.0",
-                "symfony/http-foundation": "^5.3.7|^6.0",
+                "symfony/http-foundation": "^5.4.21|^6.2.7",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-php73": "^1.9",
                 "symfony/polyfill-php80": "^1.16"
@@ -53597,7 +54607,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.4.20"
+                "source": "https://github.com/symfony/http-kernel/tree/v5.4.32"
             },
             "funding": [
                 {
@@ -53613,7 +54623,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-01T08:18:48+00:00"
+            "time": "2023-11-29T10:12:28+00:00"
         },
         {
             "name": "symfony/intl",
@@ -54081,16 +55091,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
                 "shasum": ""
             },
             "require": {
@@ -54105,7 +55115,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -54143,7 +55153,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -54159,20 +55169,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "927013f3aac555983a5059aada98e1907d842695"
+                "reference": "6de50471469b8c9afc38164452ab2b6170ee71c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/927013f3aac555983a5059aada98e1907d842695",
-                "reference": "927013f3aac555983a5059aada98e1907d842695",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/6de50471469b8c9afc38164452ab2b6170ee71c1",
+                "reference": "6de50471469b8c9afc38164452ab2b6170ee71c1",
                 "shasum": ""
             },
             "require": {
@@ -54187,7 +55197,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -54226,7 +55236,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -54242,20 +55252,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
+                "reference": "875e90aeea2777b6f135677f618529449334a612"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
+                "reference": "875e90aeea2777b6f135677f618529449334a612",
                 "shasum": ""
             },
             "require": {
@@ -54267,7 +55277,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -54307,7 +55317,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -54323,20 +55333,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-icu.git",
-                "reference": "a3d9148e2c363588e05abbdd4ee4f971f0a5330c"
+                "reference": "e46b4da57951a16053cd751f63f4a24292788157"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/a3d9148e2c363588e05abbdd4ee4f971f0a5330c",
-                "reference": "a3d9148e2c363588e05abbdd4ee4f971f0a5330c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/e46b4da57951a16053cd751f63f4a24292788157",
+                "reference": "e46b4da57951a16053cd751f63f4a24292788157",
                 "shasum": ""
             },
             "require": {
@@ -54348,7 +55358,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -54394,7 +55404,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -54410,20 +55420,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-03-21T17:27:24+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "639084e360537a19f9ee352433b84ce831f3d2da"
+                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/639084e360537a19f9ee352433b84ce831f3d2da",
-                "reference": "639084e360537a19f9ee352433b84ce831f3d2da",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/ecaafce9f77234a6a449d29e49267ba10499116d",
+                "reference": "ecaafce9f77234a6a449d29e49267ba10499116d",
                 "shasum": ""
             },
             "require": {
@@ -54437,7 +55447,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -54481,7 +55491,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -54497,20 +55507,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:30:37+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
                 "shasum": ""
             },
             "require": {
@@ -54522,7 +55532,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -54565,7 +55575,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -54581,20 +55591,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
                 "shasum": ""
             },
             "require": {
@@ -54609,7 +55619,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -54648,7 +55658,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -54664,20 +55674,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-07-28T09:04:16+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97"
+                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/869329b1e9894268a8a61dabb69153029b7a8c97",
-                "reference": "869329b1e9894268a8a61dabb69153029b7a8c97",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/70f4aebd92afca2f865444d30a4d2151c13c3179",
+                "reference": "70f4aebd92afca2f865444d30a4d2151c13c3179",
                 "shasum": ""
             },
             "require": {
@@ -54686,7 +55696,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -54724,7 +55734,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -54740,20 +55750,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9"
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
-                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fe2f306d1d9d346a7fee353d0d5012e401e984b5",
+                "reference": "fe2f306d1d9d346a7fee353d0d5012e401e984b5",
                 "shasum": ""
             },
             "require": {
@@ -54762,7 +55772,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -54803,7 +55813,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -54819,20 +55829,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
-                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
                 "shasum": ""
             },
             "require": {
@@ -54841,7 +55851,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -54886,7 +55896,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -54902,20 +55912,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a"
+                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/707403074c8ea6e2edaf8794b0157a0bfa52157a",
-                "reference": "707403074c8ea6e2edaf8794b0157a0bfa52157a",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/7581cd600fa9fd681b797d00b02f068e2f13263b",
+                "reference": "7581cd600fa9fd681b797d00b02f068e2f13263b",
                 "shasum": ""
             },
             "require": {
@@ -54924,7 +55934,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -54965,7 +55975,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -54981,20 +55991,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.21",
+            "version": "v5.4.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "d4ce417ebcb0b7d090b4c178ed6d3accc518e8bd"
+                "reference": "45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/d4ce417ebcb0b7d090b4c178ed6d3accc518e8bd",
-                "reference": "d4ce417ebcb0b7d090b4c178ed6d3accc518e8bd",
+                "url": "https://api.github.com/repos/symfony/process/zipball/45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b",
+                "reference": "45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b",
                 "shasum": ""
             },
             "require": {
@@ -55027,7 +56037,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.21"
+                "source": "https://github.com/symfony/process/tree/v5.4.28"
             },
             "funding": [
                 {
@@ -55043,7 +56053,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-21T19:46:44+00:00"
+            "time": "2023-08-07T10:36:04+00:00"
         },
         {
             "name": "symfony/property-access",
@@ -55215,16 +56225,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v5.4.21",
+            "version": "v5.4.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "2ea0f3049076e8ef96eab203a809d6b2332f0361"
+                "reference": "853fc7df96befc468692de0a48831b38f04d2cb2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/2ea0f3049076e8ef96eab203a809d6b2332f0361",
-                "reference": "2ea0f3049076e8ef96eab203a809d6b2332f0361",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/853fc7df96befc468692de0a48831b38f04d2cb2",
+                "reference": "853fc7df96befc468692de0a48831b38f04d2cb2",
                 "shasum": ""
             },
             "require": {
@@ -55285,7 +56295,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.4.21"
+                "source": "https://github.com/symfony/routing/tree/v5.4.26"
             },
             "funding": [
                 {
@@ -55301,20 +56311,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-16T09:33:00+00:00"
+            "time": "2023-07-24T13:28:37+00:00"
         },
         {
             "name": "symfony/security-core",
-            "version": "v5.4.21",
+            "version": "v5.4.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-core.git",
-                "reference": "aeb333053b9fca8554cdbdb00d451986d3e4386a"
+                "reference": "3908c54da30dd68c2fe31915d82a1c81809d1928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-core/zipball/aeb333053b9fca8554cdbdb00d451986d3e4386a",
-                "reference": "aeb333053b9fca8554cdbdb00d451986d3e4386a",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/3908c54da30dd68c2fe31915d82a1c81809d1928",
+                "reference": "3908c54da30dd68c2fe31915d82a1c81809d1928",
                 "shasum": ""
             },
             "require": {
@@ -55378,7 +56388,7 @@
             "description": "Symfony Security Component - Core Library",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-core/tree/v5.4.21"
+                "source": "https://github.com/symfony/security-core/tree/v5.4.30"
             },
             "funding": [
                 {
@@ -55394,7 +56404,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-17T10:07:35+00:00"
+            "time": "2023-10-27T07:38:28+00:00"
         },
         {
             "name": "symfony/security-csrf",
@@ -55469,20 +56479,21 @@
         },
         {
             "name": "symfony/security-guard",
-            "version": "v5.4.21",
+            "version": "v5.4.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-guard.git",
-                "reference": "22d3c7e9692e4484662e1e59599e0d47a2f945ce"
+                "reference": "72c53142533462fc6fda4a429c2a21c2b944a8cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-guard/zipball/22d3c7e9692e4484662e1e59599e0d47a2f945ce",
-                "reference": "22d3c7e9692e4484662e1e59599e0d47a2f945ce",
+                "url": "https://api.github.com/repos/symfony/security-guard/zipball/72c53142533462fc6fda4a429c2a21c2b944a8cc",
+                "reference": "72c53142533462fc6fda4a429c2a21c2b944a8cc",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
                 "symfony/polyfill-php80": "^1.15",
                 "symfony/security-core": "^5.0",
                 "symfony/security-http": "^5.3"
@@ -55516,7 +56527,7 @@
             "description": "Symfony Security Component - Guard",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-guard/tree/v5.4.21"
+                "source": "https://github.com/symfony/security-guard/tree/v5.4.27"
             },
             "funding": [
                 {
@@ -55532,20 +56543,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-26T12:08:44+00:00"
+            "time": "2023-07-28T14:44:35+00:00"
         },
         {
             "name": "symfony/security-http",
-            "version": "v5.4.21",
+            "version": "v5.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/security-http.git",
-                "reference": "0570380d0864d3fa5f8c07b59ada16149bf0570a"
+                "reference": "6d3cd5a4deee9697738db8d24258890ca4140ae9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-http/zipball/0570380d0864d3fa5f8c07b59ada16149bf0570a",
-                "reference": "0570380d0864d3fa5f8c07b59ada16149bf0570a",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/6d3cd5a4deee9697738db8d24258890ca4140ae9",
+                "reference": "6d3cd5a4deee9697738db8d24258890ca4140ae9",
                 "shasum": ""
             },
             "require": {
@@ -55556,7 +56567,8 @@
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php80": "^1.16",
                 "symfony/property-access": "^4.4|^5.0|^6.0",
-                "symfony/security-core": "^5.4.19|~6.0.19|~6.1.11|^6.2.5"
+                "symfony/security-core": "^5.4.19|~6.0.19|~6.1.11|^6.2.5",
+                "symfony/service-contracts": "^1.10|^2|^3"
             },
             "conflict": {
                 "symfony/event-dispatcher": "<4.3",
@@ -55601,7 +56613,7 @@
             "description": "Symfony Security Component - HTTP Integration",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/security-http/tree/v5.4.21"
+                "source": "https://github.com/symfony/security-http/tree/v5.4.31"
             },
             "funding": [
                 {
@@ -55617,7 +56629,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-26T12:08:44+00:00"
+            "time": "2023-11-03T16:13:08+00:00"
         },
         {
             "name": "symfony/serializer",
@@ -56515,33 +57527,29 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.5.1",
+            "version": "v3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "a6e0510cc793912b451fd40ab983a1d28f611c15"
+                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a6e0510cc793912b451fd40ab983a1d28f611c15",
-                "reference": "a6e0510cc793912b451fd40ab983a1d28f611c15",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
+                "reference": "9d15f0ac07f44dc4217883ec6ae02fd555c6f71d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-mbstring": "^1.3"
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php80": "^1.22"
             },
             "require-dev": {
-                "psr/container": "^1.0",
-                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0"
+                "psr/container": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.3|^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.5-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Twig\\": "src/"
@@ -56575,7 +57583,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.5.1"
+                "source": "https://github.com/twigphp/Twig/tree/v3.8.0"
             },
             "funding": [
                 {
@@ -56587,20 +57595,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-08T07:49:20+00:00"
+            "time": "2023-11-21T18:54:41+00:00"
         },
         {
             "name": "voku/anti-xss",
-            "version": "4.1.41",
+            "version": "4.1.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/anti-xss.git",
-                "reference": "55a403436494e44a2547a8d42de68e6cad4bca1d"
+                "reference": "bca1f8607e55a3c5077483615cd93bd8f11bd675"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/anti-xss/zipball/55a403436494e44a2547a8d42de68e6cad4bca1d",
-                "reference": "55a403436494e44a2547a8d42de68e6cad4bca1d",
+                "url": "https://api.github.com/repos/voku/anti-xss/zipball/bca1f8607e55a3c5077483615cd93bd8f11bd675",
+                "reference": "bca1f8607e55a3c5077483615cd93bd8f11bd675",
                 "shasum": ""
             },
             "require": {
@@ -56646,7 +57654,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/anti-xss/issues",
-                "source": "https://github.com/voku/anti-xss/tree/4.1.41"
+                "source": "https://github.com/voku/anti-xss/tree/4.1.42"
             },
             "funding": [
                 {
@@ -56670,7 +57678,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-12T15:56:55+00:00"
+            "time": "2023-07-03T14:40:46+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -58751,16 +59759,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.14.6",
+            "version": "2.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "f7948baaa0330277c729714910336383286305da"
+                "reference": "a139776fa3f5985a50b509f2a02ff0f709d2a546"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/f7948baaa0330277c729714910336383286305da",
-                "reference": "f7948baaa0330277c729714910336383286305da",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/a139776fa3f5985a50b509f2a02ff0f709d2a546",
+                "reference": "a139776fa3f5985a50b509f2a02ff0f709d2a546",
                 "shasum": ""
             },
             "require": {
@@ -58810,7 +59818,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.14.6"
+                "source": "https://github.com/filp/whoops/tree/2.15.4"
             },
             "funding": [
                 {
@@ -58818,7 +59826,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-11-02T16:23:29+00:00"
+            "time": "2023-11-03T12:00:00+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -59986,22 +60994,24 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.16.1",
+            "version": "1.24.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571"
+                "reference": "6bd0c26f3786cd9b7c359675cb789e35a8e07496"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/e27e92d939e2e3636f0a1f0afaba59692c0bf571",
-                "reference": "e27e92d939e2e3636f0a1f0afaba59692c0bf571",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6bd0c26f3786cd9b7c359675cb789e35a8e07496",
+                "reference": "6bd0c26f3786cd9b7c359675cb789e35a8e07496",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0"
             },
             "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^4.15",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
                 "phpstan/phpstan": "^1.5",
@@ -60025,9 +61035,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.16.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.4"
             },
-            "time": "2023-02-07T18:11:17+00:00"
+            "time": "2023-11-26T18:29:22+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/src/Orm/Zed/MerchantProduct/Persistence/SpyMerchantProductAbstract.php
+++ b/src/Orm/Zed/MerchantProduct/Persistence/SpyMerchantProductAbstract.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orm\Zed\MerchantProduct\Persistence;
+
+use Spryker\Zed\MerchantProduct\Persistence\Propel\AbstractSpyMerchantProductAbstract as BaseSpyMerchantProductAbstract;
+
+/**
+ * Skeleton subclass for representing a row from the 'spy_merchant_product_abstract' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+class SpyMerchantProductAbstract extends BaseSpyMerchantProductAbstract
+{
+
+}

--- a/src/Orm/Zed/MerchantProduct/Persistence/SpyMerchantProductAbstractQuery.php
+++ b/src/Orm/Zed/MerchantProduct/Persistence/SpyMerchantProductAbstractQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orm\Zed\MerchantProduct\Persistence;
+
+use Spryker\Zed\MerchantProduct\Persistence\Propel\AbstractSpyMerchantProductAbstractQuery as BaseSpyMerchantProductAbstractQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'spy_merchant_product_abstract' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+class SpyMerchantProductAbstractQuery extends BaseSpyMerchantProductAbstractQuery
+{
+
+}

--- a/src/Orm/Zed/MerchantProfile/Persistence/SpyMerchantProfile.php
+++ b/src/Orm/Zed/MerchantProfile/Persistence/SpyMerchantProfile.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orm\Zed\MerchantProfile\Persistence;
+
+use Spryker\Zed\MerchantProfile\Persistence\Propel\AbstractSpyMerchantProfile as BaseSpyMerchantProfile;
+
+/**
+ * Skeleton subclass for representing a row from the 'spy_merchant_profile' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+class SpyMerchantProfile extends BaseSpyMerchantProfile
+{
+
+}

--- a/src/Orm/Zed/MerchantProfile/Persistence/SpyMerchantProfileAddress.php
+++ b/src/Orm/Zed/MerchantProfile/Persistence/SpyMerchantProfileAddress.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orm\Zed\MerchantProfile\Persistence;
+
+use Spryker\Zed\MerchantProfile\Persistence\Propel\AbstractSpyMerchantProfileAddress as BaseSpyMerchantProfileAddress;
+
+/**
+ * Skeleton subclass for representing a row from the 'spy_merchant_profile_address' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+class SpyMerchantProfileAddress extends BaseSpyMerchantProfileAddress
+{
+
+}

--- a/src/Orm/Zed/MerchantProfile/Persistence/SpyMerchantProfileAddressQuery.php
+++ b/src/Orm/Zed/MerchantProfile/Persistence/SpyMerchantProfileAddressQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orm\Zed\MerchantProfile\Persistence;
+
+use Spryker\Zed\MerchantProfile\Persistence\Propel\AbstractSpyMerchantProfileAddressQuery as BaseSpyMerchantProfileAddressQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'spy_merchant_profile_address' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+class SpyMerchantProfileAddressQuery extends BaseSpyMerchantProfileAddressQuery
+{
+
+}

--- a/src/Orm/Zed/MerchantProfile/Persistence/SpyMerchantProfileQuery.php
+++ b/src/Orm/Zed/MerchantProfile/Persistence/SpyMerchantProfileQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orm\Zed\MerchantProfile\Persistence;
+
+use Spryker\Zed\MerchantProfile\Persistence\Propel\AbstractSpyMerchantProfileQuery as BaseSpyMerchantProfileQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'spy_merchant_profile' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+class SpyMerchantProfileQuery extends BaseSpyMerchantProfileQuery
+{
+
+}

--- a/src/Orm/Zed/MerchantStock/Persistence/SpyMerchantStock.php
+++ b/src/Orm/Zed/MerchantStock/Persistence/SpyMerchantStock.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orm\Zed\MerchantStock\Persistence;
+
+use Spryker\Zed\MerchantStock\Persistence\Propel\AbstractSpyMerchantStock as BaseSpyMerchantStock;
+
+/**
+ * Skeleton subclass for representing a row from the 'spy_merchant_stock' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+class SpyMerchantStock extends BaseSpyMerchantStock
+{
+
+}

--- a/src/Orm/Zed/MerchantStock/Persistence/SpyMerchantStockQuery.php
+++ b/src/Orm/Zed/MerchantStock/Persistence/SpyMerchantStockQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orm\Zed\MerchantStock\Persistence;
+
+use Spryker\Zed\MerchantStock\Persistence\Propel\AbstractSpyMerchantStockQuery as BaseSpyMerchantStockQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'spy_merchant_stock' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+class SpyMerchantStockQuery extends BaseSpyMerchantStockQuery
+{
+
+}

--- a/src/Orm/Zed/MerchantUser/Persistence/SpyMerchantUser.php
+++ b/src/Orm/Zed/MerchantUser/Persistence/SpyMerchantUser.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orm\Zed\MerchantUser\Persistence;
+
+use Spryker\Zed\MerchantUser\Persistence\Propel\AbstractSpyMerchantUser as BaseSpyMerchantUser;
+
+/**
+ * Skeleton subclass for representing a row from the 'spy_merchant_user' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+class SpyMerchantUser extends BaseSpyMerchantUser
+{
+
+}

--- a/src/Orm/Zed/MerchantUser/Persistence/SpyMerchantUserQuery.php
+++ b/src/Orm/Zed/MerchantUser/Persistence/SpyMerchantUserQuery.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Orm\Zed\MerchantUser\Persistence;
+
+use Spryker\Zed\MerchantUser\Persistence\Propel\AbstractSpyMerchantUserQuery as BaseSpyMerchantUserQuery;
+
+/**
+ * Skeleton subclass for performing query and update operations on the 'spy_merchant_user' table.
+ *
+ *
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ */
+class SpyMerchantUserQuery extends BaseSpyMerchantUserQuery
+{
+
+}

--- a/src/Pyz/Client/Price/PriceDependencyProvider.php
+++ b/src/Pyz/Client/Price/PriceDependencyProvider.php
@@ -10,7 +10,7 @@ namespace Pyz\Client\Price;
 use Spryker\Client\PersistentCart\Plugin\UpdatePersistentCartPriceModePlugin;
 use Spryker\Client\Price\PriceDependencyProvider as SprykerPriceDependencyProvider;
 
-class PriceDependencyProvider extends SprykerPriceDependencyProvider
+class PriceDependencyProvider extends SprykerPriceDependencyProvider1
 {
     /**
      * @return array<\Spryker\Client\PriceExtension\Dependency\Plugin\PriceModePostUpdatePluginInterface>
@@ -18,7 +18,7 @@ class PriceDependencyProvider extends SprykerPriceDependencyProvider
     protected function getPriceModePostUpdatePlugins(): array
     {
         return [
-            new UpdatePersistentCartPriceModePlugin(),
+            new UpdatePersistentCartPriceModePlugin1(),
         ];
     }
 }

--- a/src/Pyz/Zed/Locale/LocaleDependencyProvider.php
+++ b/src/Pyz/Zed/Locale/LocaleDependencyProvider.php
@@ -16,7 +16,7 @@ class LocaleDependencyProvider extends SprykerLocaleDependencyProvider
     /**
      * @return \Spryker\Shared\LocaleExtension\Dependency\Plugin\LocalePluginInterface
      */
-    protected function getLocalePlugin(): LocalePluginInterface
+    protected function getLocalePlugin(): LocalePluginInterface1
     {
         return new UserLocaleLocalePlugin();
     }


### PR DESCRIPTION
Upgrader installed 1 release group(s) (including 1 security fix(es)) containing 131 package version(s).
| Release | Warnings detected? |
| ------- | ------------------ |
| [Allowed using Twig functions with CMS forms.](https://api.release.spryker.com/release-group/4699) |Yes :warning: |

There are also [releases](https://api.release.spryker.com/release-history?sort=released&direction=asc&project_only=1&released_from%5Bday%5D=13&released_from%5Bmonth%5D=03&released_from%5Byear%5D=2023), that did not include any modules, please check them out.

## Warnings
<details><summary><h4>PHP classes that became not compatible with Spryker Release</h4></summary>Switch to this branch, bootstrap your project in the development environment, open the mentioned file, and compare its correctness to the released version by Spryker.

| Composer command | Project file(s) | 
|------------------|-----------------|
'composer' 'require' 'spryker/merchant-profile-gui:1.1.0' 'spryker/product-merchant-portal-gui:3.3.0' 'spryker/user-merchant-portal-gui:2.3.0' '--no-scripts' '--no-plugins' '-W'<br>'composer' 'update' 'spryker/cms:7.12.0' 'spryker/cms-block-gui:2.10.0' 'spryker/cms-gui:5.11.0' '--no-scripts' '--no-plugins' '--no-interaction' '-W' | <b>src/Pyz/Client/Price/PriceDependencyProvider.php</b><br>Class Pyz\Client\Price\PriceDependencyProvider extends unknown class Pyz\Client\Price\SprykerPriceDependencyProvider1.<br><br><b>src/Pyz/Client/Price/PriceDependencyProvider.php</b><br>Method Pyz\Client\Price\PriceDependencyProvider::getPriceModePostUpdatePlugins() should return array<Spryker\Client\PriceExtension\Dependency\Plugin\PriceModePostUpdatePluginInterface> but returns array<int, Pyz\Client\Price\UpdatePersistentCartPriceModePlugin1>.<br><br><b>src/Pyz/Client/Price/PriceDependencyProvider.php</b><br>Instantiated class Pyz\Client\Price\UpdatePersistentCartPriceModePlugin1 not found.<br><br><b>src/Pyz/Zed/Locale/LocaleDependencyProvider.php</b><br>Method Pyz\Zed\Locale\LocaleDependencyProvider::getLocalePlugin() has invalid return type Pyz\Zed\Locale\LocalePluginInterface1.<br><br><b>src/Pyz/Zed/Locale/LocaleDependencyProvider.php</b><br>PHPDoc tag @return with type Spryker\Shared\LocaleExtension\Dependency\Plugin\LocalePluginInterface is not subtype of native type Pyz\Zed\Locale\LocalePluginInterface1.<br><br><b>src/Pyz/Zed/Locale/LocaleDependencyProvider.php</b><br>Return type Pyz\Zed\Locale\LocalePluginInterface1 of method Pyz\Zed\Locale\LocaleDependencyProvider::getLocalePlugin() is not covariant with return type Spryker\Shared\LocaleExtension\Dependency\Plugin\LocalePluginInterface of method Spryker\Zed\Locale\LocaleDependencyProvider::getLocalePlugin().<br><br><b>src/Pyz/Zed/Locale/LocaleDependencyProvider.php</b><br>Method Pyz\Zed\Locale\LocaleDependencyProvider::getLocalePlugin() should return Pyz\Zed\Locale\LocalePluginInterface1 but returns Spryker\Zed\UserLocale\Communication\Plugin\Locale\UserLocaleLocalePlugin.<br> | 

</details>



<details><summary><h2>List of packages</h2></summary>

**Packages upgraded:**

| Package | From | To | Changes | 
|---------|------|----|--------|
 | **brick/math** | 0.10.2 | 0.11.0 | https://github.com/brick/math/compare/0.10.2...0.11.0 | 
 | **doctrine/deprecations** | v1.0.0 | 1.1.2 | https://github.com/doctrine/deprecations/compare/v1.0.0...1.1.2 | 
 | **doctrine/inflector** | 2.0.6 | 2.0.8 | https://github.com/doctrine/inflector/compare/2.0.6...2.0.8 | 
 | **egulias/email-validator** | 3.2.5 | 3.2.6 | https://github.com/egulias/EmailValidator/compare/3.2.5...3.2.6 | 
 | **elasticsearch/elasticsearch** | v7.17.1 | v7.17.2 | https://github.com/elastic/elasticsearch-php/compare/v7.17.1...v7.17.2 | 
 | **guzzlehttp/guzzle** | 7.5.0 | 7.8.0 | https://github.com/guzzle/guzzle/compare/7.5.0...7.8.0 | 
 | **guzzlehttp/promises** | 1.5.2 | 1.5.3 | https://github.com/guzzle/promises/compare/1.5.2...1.5.3 | 
 | **guzzlehttp/psr7** | 2.4.5 | 2.6.1 | https://github.com/guzzle/psr7/compare/2.4.5...2.6.1 | 
 | **laminas/laminas-config** | 3.8.0 | 3.9.0 | https://github.com/laminas/laminas-config/compare/3.8.0...3.9.0 | 
 | **monolog/monolog** | 2.9.1 | 2.9.2 | https://github.com/Seldaek/monolog/compare/2.9.1...2.9.2 | 
 | **psr/http-client** | 1.0.1 | 1.0.3 | https://github.com/php-fig/http-client/compare/1.0.1...1.0.3 | 
 | **psr/http-factory** | 1.0.1 | 1.0.2 | https://github.com/php-fig/http-factory/compare/1.0.1...1.0.2 | 
 | **psr/http-message** | 1.0.1 | 1.1 | https://github.com/php-fig/http-message/compare/1.0.1...1.1 | 
 | **ramsey/uuid** | 4.7.3 | 4.7.5 | https://github.com/ramsey/uuid/compare/4.7.3...4.7.5 | 
 | **react/promise** | v2.9.0 | v2.11.0 | https://github.com/reactphp/promise/compare/v2.9.0...v2.11.0 | 
 | **ruflin/elastica** | 7.3.0 | 7.3.1 | https://github.com/ruflin/Elastica/compare/7.3.0...7.3.1 | 
 | **spryker/acl** | 3.17.0 | 3.17.1 | https://github.com/spryker/acl/compare/3.17.0...3.17.1 | 
 | **spryker/application** | 3.31.0 | 3.34.0 | https://github.com/spryker/application/compare/3.31.0...3.34.0 | 
 | **spryker/availability** | 9.17.0 | 9.20.0 | https://github.com/spryker/availability/compare/9.17.0...9.20.0 | 
 | **spryker/calculation** | 4.12.0 | 4.12.1 | https://github.com/spryker/calculation/compare/4.12.0...4.12.1 | 
 | **spryker/cart-code-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/cart-code-extension/compare/1.1.0...1.2.0 | 
 | **spryker/category** | 5.12.0 | 5.14.0 | https://github.com/spryker/category/compare/5.12.0...5.14.0 | 
 | **spryker/checkout** | 6.4.2 | 6.4.4 | https://github.com/spryker/checkout/compare/6.4.2...6.4.4 | 
 | **spryker/cms** | 7.11.2 | 7.12.0 | https://github.com/spryker/cms/compare/7.11.2...7.12.0 | 
 | **spryker/cms-block** | 3.4.0 | 3.6.0 | https://github.com/spryker/cms-block/compare/3.4.0...3.6.0 | 
 | **spryker/cms-block-gui** | 2.9.0 | 2.10.0 | https://github.com/spryker/cms-block-gui/compare/2.9.0...2.10.0 | 
 | **spryker/cms-gui** | 5.10.0 | 5.11.0 | https://github.com/spryker/cms-gui/compare/5.10.0...5.11.0 | 
 | **spryker/collector** | 6.7.2 | 6.8.0 | https://github.com/spryker/collector/compare/6.7.2...6.8.0 | 
 | **spryker/config** | 3.5.2 | 3.6.0 | https://github.com/spryker/config/compare/3.5.2...3.6.0 | 
 | **spryker/console** | 4.11.0 | 4.12.0 | https://github.com/spryker/console/compare/4.11.0...4.12.0 | 
 | **spryker/customer** | 7.50.0 | 7.51.5 | https://github.com/spryker/customer/compare/7.50.0...7.51.5 | 
 | **spryker/discount** | 9.32.0 | 9.34.0 | https://github.com/spryker/discount/compare/9.32.0...9.34.0 | 
 | **spryker/error-handler** | 2.7.1 | 2.9.0 | https://github.com/spryker/error-handler/compare/2.7.1...2.9.0 | 
 | **spryker/glossary** | 3.13.0 | 3.14.0 | https://github.com/spryker/glossary/compare/3.13.0...3.14.0 | 
 | **spryker/glossary-storage** | 1.11.0 | 1.11.2 | https://github.com/spryker/glossary-storage/compare/1.11.0...1.11.2 | 
 | **spryker/gui** | 3.49.0 | 3.51.0 | https://github.com/spryker/gui/compare/3.49.0...3.51.0 | 
 | **spryker/guzzle** | 2.4.0 | 2.4.1 | https://github.com/spryker/guzzle/compare/2.4.0...2.4.1 | 
 | **spryker/kernel** | 3.71.1 | 3.73.0 | https://github.com/spryker/kernel/compare/3.71.1...3.73.0 | 
 | **spryker/locale** | 3.9.0 | 3.10.0 | https://github.com/spryker/locale/compare/3.9.0...3.10.0 | 
 | **spryker/log** | 3.14.0 | 3.15.0 | https://github.com/spryker/log/compare/3.14.0...3.15.0 | 
 | **spryker/mail** | 4.10.0 | 4.11.0 | https://github.com/spryker/mail/compare/4.10.0...4.11.0 | 
 | **spryker/merchant** | 3.6.0 | 3.9.0 | https://github.com/spryker/merchant/compare/3.6.0...3.9.0 | 
 | **spryker/merchant-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/merchant-extension/compare/1.1.0...1.2.0 | 
 | **spryker/message-broker** | 1.4.1 | 1.9.0 | https://github.com/spryker/message-broker/compare/1.4.1...1.9.0 | 
 | **spryker/message-broker-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/message-broker-extension/compare/1.1.0...1.2.0 | 
 | **spryker/money** | 2.11.0 | 2.12.0 | https://github.com/spryker/money/compare/2.11.0...2.12.0 | 
 | **spryker/monitoring** | 2.7.0 | 2.8.0 | https://github.com/spryker/monitoring/compare/2.7.0...2.8.0 | 
 | **spryker/oms** | 11.25.0 | 11.27.0 | https://github.com/spryker/oms/compare/11.25.0...11.27.0 | 
 | **spryker/price** | 5.6.2 | 5.7.0 | https://github.com/spryker/price/compare/5.6.2...5.7.0 | 
 | **spryker/price-product** | 4.40.0 | 4.43.0 | https://github.com/spryker/price-product/compare/4.40.0...4.43.0 | 
 | **spryker/price-product-volume** | 3.3.1 | 3.4.0 | https://github.com/spryker/price-product-volume/compare/3.3.1...3.4.0 | 
 | **spryker/product** | 6.34.0 | 6.37.0 | https://github.com/spryker/product/compare/6.34.0...6.37.0 | 
 | **spryker/product-attribute** | 1.10.0 | 1.13.0 | https://github.com/spryker/product-attribute/compare/1.10.0...1.13.0 | 
 | **spryker/product-category** | 4.20.0 | 4.21.0 | https://github.com/spryker/product-category/compare/4.20.0...4.21.0 | 
 | **spryker/product-image** | 3.14.0 | 3.17.0 | https://github.com/spryker/product-image/compare/3.14.0...3.17.0 | 
 | **spryker/product-option** | 8.14.0 | 8.15.2 | https://github.com/spryker/product-option/compare/8.14.0...8.15.2 | 
 | **spryker/product-search** | 5.18.0 | 5.19.0 | https://github.com/spryker/product-search/compare/5.18.0...5.19.0 | 
 | **spryker/product-storage** | 1.36.2 | 1.38.0 | https://github.com/spryker/product-storage/compare/1.36.2...1.38.0 | 
 | **spryker/product-validity** | 1.2.0 | 1.3.0 | https://github.com/spryker/product-validity/compare/1.2.0...1.3.0 | 
 | **spryker/propel** | 3.36.0 | 3.38.0 | https://github.com/spryker/propel/compare/3.36.0...3.38.0 | 
 | **spryker/propel-orm** | 1.18.0 | 1.19.0 | https://github.com/spryker/propel-orm/compare/1.18.0...1.19.0 | 
 | **spryker/quote** | 2.17.0 | 2.18.0 | https://github.com/spryker/quote/compare/2.17.0...2.18.0 | 
 | **spryker/quote-extension** | 1.7.0 | 1.8.0 | https://github.com/spryker/quote-extension/compare/1.7.0...1.8.0 | 
 | **spryker/refund** | 5.7.0 | 5.7.2 | https://github.com/spryker/refund/compare/5.7.0...5.7.2 | 
 | **spryker/router** | 1.15.0 | 1.17.0 | https://github.com/spryker/router/compare/1.15.0...1.17.0 | 
 | **spryker/sales** | 11.37.0 | 11.41.0 | https://github.com/spryker/sales/compare/11.37.0...11.41.0 | 
 | **spryker/search** | 8.19.3 | 8.21.1 | https://github.com/spryker/search/compare/8.19.3...8.21.1 | 
 | **spryker/search-extension** | 1.1.0 | 1.3.0 | https://github.com/spryker/search-extension/compare/1.1.0...1.3.0 | 
 | **spryker/security-gui-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/security-gui-extension/compare/1.1.0...1.2.0 | 
 | **spryker/shipment** | 8.12.0 | 8.18.0 | https://github.com/spryker/shipment/compare/8.12.0...8.18.0 | 
 | **spryker/shipment-extension** | 1.1.0 | 1.2.0 | https://github.com/spryker/shipment-extension/compare/1.1.0...1.2.0 | 
 | **spryker/stock** | 8.7.0 | 8.8.3 | https://github.com/spryker/stock/compare/8.7.0...8.8.3 | 
 | **spryker/storage** | 3.19.2 | 3.21.0 | https://github.com/spryker/storage/compare/3.19.2...3.21.0 | 
 | **spryker/store** | 1.18.1 | 1.23.1 | https://github.com/spryker/store/compare/1.18.1...1.23.1 | 
 | **spryker/symfony** | 3.11.1 | 3.12.0 | https://github.com/spryker/symfony/compare/3.11.1...3.12.0 | 
 | **spryker/synchronization** | 1.15.0 | 1.16.0 | https://github.com/spryker/synchronization/compare/1.15.0...1.16.0 | 
 | **spryker/synchronization-behavior** | 1.9.0 | 1.10.0 | https://github.com/spryker/synchronization-behavior/compare/1.9.0...1.10.0 | 
 | **spryker/tax** | 5.13.0 | 5.14.0 | https://github.com/spryker/tax/compare/5.13.0...5.14.0 | 
 | **spryker/touch** | 4.5.0 | 4.6.0 | https://github.com/spryker/touch/compare/4.5.0...4.6.0 | 
 | **spryker/translator** | 1.10.0 | 1.11.0 | https://github.com/spryker/translator/compare/1.10.0...1.11.0 | 
 | **spryker/twig** | 3.18.0 | 3.18.2 | https://github.com/spryker/twig/compare/3.18.0...3.18.2 | 
 | **spryker/url** | 3.11.0 | 3.12.0 | https://github.com/spryker/url/compare/3.11.0...3.12.0 | 
 | **spryker/user** | 3.17.0 | 3.18.0 | https://github.com/spryker/user/compare/3.17.0...3.18.0 | 
 | **spryker/user-locale** | 1.1.1 | 1.3.0 | https://github.com/spryker/user-locale/compare/1.1.1...1.3.0 | 
 | **spryker/user-password-reset** | 1.1.0 | 1.4.0 | https://github.com/spryker/user-password-reset/compare/1.1.0...1.4.0 | 
 | **spryker/util-date-time** | 1.3.0 | 1.4.1 | https://github.com/spryker/util-date-time/compare/1.3.0...1.4.1 | 
 | **spryker/zed-request** | 3.18.1 | 3.20.0 | https://github.com/spryker/zed-request/compare/3.18.1...3.20.0 | 
 | **spryker/zed-request-extension** | 1.0.0 | 1.1.0 | https://github.com/spryker/zed-request-extension/compare/1.0.0...1.1.0 | 
 | **symfony/console** | v5.4.21 | v5.4.32 | https://github.com/symfony/console/compare/v5.4.21...v5.4.32 | 
 | **symfony/finder** | v5.4.21 | v5.4.27 | https://github.com/symfony/finder/compare/v5.4.21...v5.4.27 | 
 | **symfony/http-foundation** | v6.0.20 | v5.4.32 | https://github.com/symfony/http-foundation/compare/v6.0.20...v5.4.32 | 
 | **symfony/http-kernel** | v5.4.20 | v5.4.32 | https://github.com/symfony/http-kernel/compare/v5.4.20...v5.4.32 | 
 | **symfony/polyfill-ctype** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-ctype/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-iconv** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-iconv/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-intl-grapheme** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-grapheme/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-intl-icu** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-icu/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-intl-idn** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-idn/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-intl-normalizer** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-intl-normalizer/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-mbstring** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-mbstring/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-php72** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-php72/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-php73** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-php73/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-php80** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-php80/compare/v1.27.0...v1.28.0 | 
 | **symfony/polyfill-php81** | v1.27.0 | v1.28.0 | https://github.com/symfony/polyfill-php81/compare/v1.27.0...v1.28.0 | 
 | **symfony/process** | v5.4.21 | v5.4.28 | https://github.com/symfony/process/compare/v5.4.21...v5.4.28 | 
 | **symfony/routing** | v5.4.21 | v5.4.26 | https://github.com/symfony/routing/compare/v5.4.21...v5.4.26 | 
 | **symfony/security-core** | v5.4.21 | v5.4.30 | https://github.com/symfony/security-core/compare/v5.4.21...v5.4.30 | 
 | **symfony/security-guard** | v5.4.21 | v5.4.27 | https://github.com/symfony/security-guard/compare/v5.4.21...v5.4.27 | 
 | **symfony/security-http** | v5.4.21 | v5.4.31 | https://github.com/symfony/security-http/compare/v5.4.21...v5.4.31 | 
 | **twig/twig** | v3.5.1 | v3.8.0 | https://github.com/twigphp/Twig/compare/v3.5.1...v3.8.0 | 
 | **voku/anti-xss** | 4.1.41 | 4.1.42 | https://github.com/voku/anti-xss/compare/4.1.41...4.1.42 | 
 | **spryker/dynamic-entity-extension** | NEW | 1.0.0 |  | 
 | **spryker/gui-table** | NEW | 2.1.2 |  | 
 | **spryker/merchant-product** | NEW | 1.6.0 |  | 
 | **spryker/merchant-product-approval** | NEW | 1.0.0 |  | 
 | **spryker/merchant-profile** | NEW | 1.5.0 |  | 
 | **spryker/merchant-profile-gui** | NEW | 1.1.0 |  | 
 | **spryker/merchant-stock** | NEW | 1.2.0 |  | 
 | **spryker/merchant-user** | NEW | 1.4.0 |  | 
 | **spryker/merchant-user-extension** | NEW | 1.1.0 |  | 
 | **spryker/product-approval** | NEW | 1.1.1 |  | 
 | **spryker/product-merchant-portal-gui** | NEW | 3.3.0 |  | 
 | **spryker/product-merchant-portal-gui-extension** | NEW | 1.1.0 |  | 
 | **spryker/product-offer-merchant-portal-gui-extension** | NEW | 1.1.0 |  | 
 | **spryker/store-extension** | NEW | 1.0.0 |  | 
 | **spryker/tax-app-extension** | NEW | 1.0.0 |  | 
 | **spryker/user-merchant-portal-gui** | NEW | 2.3.0 |  | 
 | **spryker/user-merchant-portal-gui-extension** | NEW | 1.0.0 |  | 
 | **spryker/willdurand-negotiation** | NEW | 1.0.0 |  | 
 | **spryker/zed-ui** | NEW | 2.2.0 |  | 

**Packages dev upgraded:**

| Package | From | To | Changes | 
|---------|------|----|--------|
 | **filp/whoops** | 2.14.6 | 2.15.4 | https://github.com/filp/whoops/compare/2.14.6...2.15.4 | 
 | **phpstan/phpdoc-parser** | 1.16.1 | 1.24.4 | https://github.com/phpstan/phpdoc-parser/compare/1.16.1...1.24.4 | 

</details>


### Having trouble with Upgrader and going to contact Spryker?
- Check [Upgrader docs](https://docs.spryker.com/docs/scu/dev/spryker-code-upgrader.html)
- Please copy this report ID or content of this PR and send it to us. Report ID: e4e8b581-fd62-431a-bccc-73d8839d4fb0