### PR TITLE
Auto-updating Spryker modules on 2024-01-09 14:42 for release group #5137

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ docker
 # angular
 /.angular/cache
 /.angular
+
+integrator.lock


### PR DESCRIPTION
Unfortunately Upgrader was not able to create a pull request with code changes due to errors. Please see the list below and resolve them.

## Errors :warning:
> [!IMPORTANT] 
> <b>Composer issues.</b> Problem 1
    - Root composer.json requires PHP extension ext-bcmath * but it is missing from your system. Install or enable PHP's bcmath extension.
  Problem 2
    - Root composer.json requires PHP extension ext-gd * but it is missing from your system. Install or enable PHP's gd extension.
  Problem 3
    - Root composer.json requires PHP extension ext-gmp * but it is missing from your system. Install or enable PHP's gmp extension.
  Problem 4
    - Root composer.json requires PHP extension ext-pdo_pgsql * but it is missing from your system. Install or enable PHP's pdo_pgsql extension.
  Problem 5
    - Root composer.json requires PHP extension ext-pgsql * but it is missing from your system. Install or enable PHP's pgsql extension.
  Problem 6
    - Root composer.json requires PHP extension ext-redis * but it is missing from your system. Install or enable PHP's redis extension.
  Problem 7
    - spryker-shop/customer-page 2.49.0 requires php >=8.1 -> your php version (8.0.9; overridden via config.platform, actual: 8.0.30) does not satisfy that requirement.
    - spryker-feature/customer-account-management 202307.0 requires spryker-shop/customer-page ^2.43.0 -> satisfiable by spryker-shop/customer-page[2.49.0].
    - spryker-feature/customer-account-management is locked to version 202307.0 and an update of this package was not requested.

To enable extensions, verify that they are enabled in your .ini files:
    - /etc/php/8.0/cli/php.ini
    - /etc/php/8.0/cli/conf.d/10-mysqlnd.ini
    - /etc/php/8.0/cli/conf.d/10-opcache.ini
    - /etc/php/8.0/cli/conf.d/10-pdo.ini
    - /etc/php/8.0/cli/conf.d/15-xml.ini
    - /etc/php/8.0/cli/conf.d/20-bz2.ini
    - /etc/php/8.0/cli/conf.d/20-calendar.ini
    - /etc/php/8.0/cli/conf.d/20-ctype.ini
    - /etc/php/8.0/cli/conf.d/20-curl.ini
    - /etc/php/8.0/cli/conf.d/20-dom.ini
    - /etc/php/8.0/cli/conf.d/20-exif.ini
    - /etc/php/8.0/cli/conf.d/20-ffi.ini
    - /etc/php/8.0/cli/conf.d/20-fileinfo.ini
    - /etc/php/8.0/cli/conf.d/20-ftp.ini
    - /etc/php/8.0/cli/conf.d/20-gettext.ini
    - /etc/php/8.0/cli/conf.d/20-iconv.ini
    - /etc/php/8.0/cli/conf.d/20-intl.ini
    - /etc/php/8.0/cli/conf.d/20-mbstring.ini
    - /etc/php/8.0/cli/conf.d/20-mysqli.ini
    - /etc/php/8.0/cli/conf.d/20-pcov.ini
    - /etc/php/8.0/cli/conf.d/20-pdo_mysql.ini
    - /etc/php/8.0/cli/conf.d/20-pdo_sqlite.ini
    - /etc/php/8.0/cli/conf.d/20-phar.ini
    - /etc/php/8.0/cli/conf.d/20-posix.ini
    - /etc/php/8.0/cli/conf.d/20-readline.ini
    - /etc/php/8.0/cli/conf.d/20-shmop.ini
    - /etc/php/8.0/cli/conf.d/20-simplexml.ini
    - /etc/php/8.0/cli/conf.d/20-sockets.ini
    - /etc/php/8.0/cli/conf.d/20-sqlite3.ini
    - /etc/php/8.0/cli/conf.d/20-sysvmsg.ini
    - /etc/php/8.0/cli/conf.d/20-sysvsem.ini
    - /etc/php/8.0/cli/conf.d/20-sysvshm.ini
    - /etc/php/8.0/cli/conf.d/20-tokenizer.ini
    - /etc/php/8.0/cli/conf.d/20-xdebug.ini
    - /etc/php/8.0/cli/conf.d/20-xmlreader.ini
    - /etc/php/8.0/cli/conf.d/20-xmlwriter.ini
    - /etc/php/8.0/cli/conf.d/20-xsl.ini
You can also run `php --ini` in a terminal to see which files are used by PHP in CLI mode.
Alternatively, you can run Composer with `--ignore-platform-req=ext-bcmath --ignore-platform-req=ext-gd --ignore-platform-req=ext-gmp --ignore-platform-req=ext-pdo_pgsql --ignore-platform-req=ext-pgsql --ignore-platform-req=ext-redis` to temporarily ignore these required extensions.




### Having trouble with Upgrader and going to contact Spryker?
- Check [Upgrader docs](https://docs.spryker.com/docs/scu/dev/spryker-code-upgrader.html)
- Please copy this report ID or content of this PR and send it to us. Report ID: 6d8d3a95-ce6b-4427-8188-02b4f035cecb